### PR TITLE
[Build] Fix undefined build error

### DIFF
--- a/component/soc/realtek/amebad/misc/rtl8721d_ota.c
+++ b/component/soc/realtek/amebad/misc/rtl8721d_ota.c
@@ -2136,6 +2136,7 @@ update_ota_exit:
 #endif
 
 #ifdef SDCARD_OTA_UPDATE
+#if defined(FATFS_DISK_SD) && FATFS_DISK_SD
 
 FATFS m_fs;
 
@@ -2330,4 +2331,5 @@ update_ota_exit:
 	
 	return ret;
 }
+#endif
 #endif


### PR DESCRIPTION
- Undefined error SD_disk_Driver
- SD_disk_Driver is only defined when FATFS_DISK_SD is enabled in platform_opts.h