### PR TITLE
[lwip] increase system timeout

### DIFF
--- a/component/common/api/network/include/lwipopts.h
+++ b/component/common/api/network/include/lwipopts.h
@@ -444,6 +444,11 @@ Certain platform allows computing and verifying the IP, UDP, TCP and ICMP checks
 #endif
 #endif
 
+#if defined(CONFIG_EXAMPLE_MATTER) && CONFIG_EXAMPLE_MATTER
+#undef  MEMP_NUM_SYS_TIMEOUT
+#define MEMP_NUM_SYS_TIMEOUT            14
+#endif
+
 #include "lwip/init.h"                  //for version control
 
 #ifdef __cplusplus


### PR DESCRIPTION
* Insufficient timeout when attempting to do TCP retry, increase MEMP_NUM_SYS_TIMEOUT