### PR TITLE
[build] ignore unused label

### DIFF
--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/Makefile.include.gen
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/Makefile.include.gen
@@ -370,6 +370,7 @@ GLOBAL_CFLAGS += -Wpointer-arith
 #GLOBAL_CFLAGS += -Wundef
 GLOBAL_CFLAGS += -Wno-write-strings
 GLOBAL_CFLAGS += -Wno-maybe-uninitialized
+GLOBAL_CFLAGS += -Wno-unused-label
 #GLOBAL_CFLAGS += --save-temps
 GLOBAL_CFLAGS += -c
 GLOBAL_CFLAGS += -MMD -MP


### PR DESCRIPTION
- fix build when factory data is disabled
- unused label error ignored