### PR TITLE
[build] remove af-event from build

### DIFF
--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/all_clusters_app/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/all_clusters_app/Makefile
@@ -91,7 +91,6 @@ CPPSRC += $(CHIPDIR)/src/app/server/EchoHandler.cpp
 CPPSRC += $(CHIPDIR)/src/app/server/OnboardingCodesUtil.cpp
 CPPSRC += $(CHIPDIR)/src/app/server/CommissioningWindowManager.cpp
 
-CPPSRC += $(CHIPDIR)/src/app/util/af-event.cpp
 CPPSRC += $(CHIPDIR)/src/app/util/attribute-storage.cpp
 CPPSRC += $(CHIPDIR)/src/app/util/attribute-table.cpp
 CPPSRC += $(CHIPDIR)/src/app/util/attribute-size-util.cpp

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/lighting_app/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/lighting_app/Makefile
@@ -89,7 +89,6 @@ CPPSRC += $(CHIPDIR)/src/app/server/EchoHandler.cpp
 CPPSRC += $(CHIPDIR)/src/app/server/OnboardingCodesUtil.cpp
 CPPSRC += $(CHIPDIR)/src/app/server/CommissioningWindowManager.cpp
 
-CPPSRC += $(CHIPDIR)/src/app/util/af-event.cpp
 CPPSRC += $(CHIPDIR)/src/app/util/attribute-storage.cpp
 CPPSRC += $(CHIPDIR)/src/app/util/attribute-table.cpp
 CPPSRC += $(CHIPDIR)/src/app/util/attribute-size-util.cpp

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/lighting_port/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/lighting_port/Makefile
@@ -99,7 +99,6 @@ CPPSRC += $(CHIPDIR)/src/app/server/EchoHandler.cpp
 CPPSRC += $(CHIPDIR)/src/app/server/OnboardingCodesUtil.cpp
 CPPSRC += $(CHIPDIR)/src/app/server/CommissioningWindowManager.cpp
 
-CPPSRC += $(CHIPDIR)/src/app/util/af-event.cpp
 CPPSRC += $(CHIPDIR)/src/app/util/attribute-storage.cpp
 CPPSRC += $(CHIPDIR)/src/app/util/attribute-table.cpp
 CPPSRC += $(CHIPDIR)/src/app/util/attribute-size-util.cpp


### PR DESCRIPTION
- matter SHA `d7971c0` removes af-event.[h |cpp] files
- remove af-event.cpp from all app's chip_main files