### PR TITLE
[dct] dct encryption

### DIFF
--- a/component/common/application/matter/common/port/matter_dcts.c
+++ b/component/common/application/matter/common/port/matter_dcts.c
@@ -14,6 +14,10 @@ extern "C" {
 #include "dct.h"
 #include "chip_porting.h"
 
+#if CONFIG_ENABLE_DCT_ENCRYPTION
+#include "mbedtls/aes.h"
+#endif
+
 /*
    module size is 4k, we set max module number as 12;
    if backup enabled, the total module number is 12 + 1*12 = 24, the size is 96k;
@@ -32,6 +36,77 @@ extern "C" {
 #define ENABLE_BACKUP           MATTER_KVS_ENABLE_BACKUP
 #define ENABLE_WEAR_LEVELING    MATTER_KVS_ENABLE_WEAR_LEVELING
 
+#if CONFIG_ENABLE_DCT_ENCRYPTION
+#if defined(MBEDTLS_CIPHER_MODE_CTR)
+    mbedtls_aes_context aes;
+
+    // key length 32 bytes for 256 bit encrypting, it can be 16 or 24 bytes for 128 and 192 bits encrypting mode
+    unsigned char key[] = {0xff, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0xff, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
+
+#define DCT_REGION_1 0
+#define DCT_REGION_2 1
+
+    int32_t dct_encrypt(unsigned char *input_to_encrypt, int input_len, unsigned char *encrypt_output)
+    {
+        size_t nc_off = 0;
+
+        unsigned char nonce_counter[16] = {0};
+        unsigned char stream_block[16] = {0};
+        int ret = mbedtls_aes_crypt_ctr(&aes, input_len, &nc_off, nonce_counter, stream_block, input_to_encrypt, encrypt_output);
+        return ret;
+    }
+
+    int32_t dct_decrypt(unsigned char *input_to_decrypt, int input_len, unsigned char *decrypt_output)
+    {
+        size_t nc_off1 = 0;
+        unsigned char nonce_counter1[16] = {0};
+        unsigned char stream_block1[16] = {0};
+        int ret = mbedtls_aes_crypt_ctr(&aes, input_len, &nc_off1, nonce_counter1, stream_block1, input_to_decrypt, decrypt_output);
+        return ret;
+    }
+
+    int32_t dct_set_encrypted_variable(dct_handle_t *dct_handle, char *variable_name, char *variable_value, uint16_t variable_value_length, uint8_t region)
+    {
+        int32_t ret;
+        char encrypted_data[VARIABLE_VALUE_SIZE2] = {0};
+
+        // encrypt the variable value
+        ret = dct_encrypt(variable_value, variable_value_length, encrypted_data);
+
+        // store in dct
+        if (region == DCT_REGION_1)
+            ret = dct_set_variable_new(dct_handle, variable_name, encrypted_data, variable_value_length);
+        else if (region == DCT_REGION_2)
+            ret = dct_set_variable_new2(dct_handle, variable_name, encrypted_data, variable_value_length);
+
+        return ret;
+    }
+
+    int32_t dct_get_encrypted_variable(dct_handle_t *dct_handle, char *variable_name, char *buffer, uint16_t *buffer_size, uint8_t region)
+    {
+        int32_t ret;
+        uint8_t encrypted_data[404] = {0};
+
+        // get the encrypted value from dct
+        if (region == DCT_REGION_1)
+            ret = dct_get_variable_new(dct_handle, variable_name, encrypted_data, buffer_size);
+        else if (region == DCT_REGION_2)
+            ret = dct_get_variable_new2(dct_handle, variable_name, encrypted_data, buffer_size);
+
+        if (ret != DCT_SUCCESS)
+            return ret;
+
+        // decrypt the encrypted value
+        ret = dct_decrypt(encrypted_data, *buffer_size, buffer);
+
+        return ret;
+    }
+
+#else
+#error "MBEDTLS_CIPHER_MODE_CTR must be enabled to perform DCT flash encryption" 
+#endif // MBEDTLS_CIPHER_MODE_CTR
+#endif
+
 int32_t initPref(void)
 {
     int32_t ret;
@@ -46,6 +121,12 @@ int32_t initPref(void)
         printf("dct_init2 failed with error: %d\n", ret);
     else
         printf("dct_init2 success\n");
+
+#if CONFIG_ENABLE_DCT_ENCRYPTION
+    // Initialize mbedtls aes context and set encryption key
+    mbedtls_aes_init(&aes);
+    mbedtls_aes_setkey_enc(&aes, key, 256);
+#endif
 
     return ret;
 }
@@ -64,6 +145,11 @@ int32_t deinitPref(void)
         printf("dct_format2 failed with error: %d\n", ret);
     else
         printf("dct_format2 success\n");
+
+#if CONFIG_ENABLE_DCT_ENCRYPTION
+    // free aes context
+    mbedtls_aes_free(&aes);
+#endif
 
     return ret;
 }
@@ -199,7 +285,7 @@ bool checkExist(const char *domain, const char *key)
     dct_handle_t handle;
     s32 ret = -1;
     uint16_t len = 0;
-    u8 *str = malloc(sizeof(u8) * VARIABLE_VALUE_SIZE2-4); // use the bigger buffer size
+    u8 *str = malloc(sizeof(u8) * VARIABLE_VALUE_SIZE2); // use the bigger buffer size
     char ns[15];
 
     // Loop over DCT1 modules
@@ -247,7 +333,7 @@ bool checkExist(const char *domain, const char *key)
             goto exit;
         }
 
-        len = VARIABLE_VALUE_SIZE2-4;
+        len = VARIABLE_VALUE_SIZE2;
         ret = dct_get_variable_new2(&handle, key, str, &len);
         if(ret == DCT_SUCCESS)
         {
@@ -287,7 +373,11 @@ s32 setPref_new(const char *domain, const char *key, u8 *value, size_t byteCount
 
             if (dct_remain_variable(&handle) > 0)
             {
+#if CONFIG_ENABLE_DCT_ENCRYPTION
+                ret = dct_set_encrypted_variable(&handle, key, value, byteCount, DCT_REGION_1);
+#else
                 ret = dct_set_variable_new(&handle, key, (char *)value, (uint16_t)byteCount);
+#endif
                 if (DCT_SUCCESS != ret)
                 {
                     printf("%s : dct_set_variable(%s) failed with error: %d\n" ,__FUNCTION__, key, ret);
@@ -316,7 +406,11 @@ s32 setPref_new(const char *domain, const char *key, u8 *value, size_t byteCount
 
             if (dct_remain_variable2(&handle) > 0)
             {
+#if CONFIG_ENABLE_DCT_ENCRYPTION
+                ret = dct_set_encrypted_variable(&handle, key, value, byteCount, DCT_REGION_2);
+#else
                 ret = dct_set_variable_new2(&handle, key, (char *)value, (uint16_t)byteCount);
+#endif
                 if (DCT_SUCCESS != ret)
                 {
                     printf("%s : dct_set_variable2(%s) failed with error: %d\n" ,__FUNCTION__, key, ret);
@@ -352,7 +446,11 @@ s32 getPref_bool_new(const char *domain, const char *key, u8 *val)
             printf("%s : dct_open_module(%s) failed with error: %d\n" ,__FUNCTION__, ns, ret);
             goto exit;
         }
+#if CONFIG_ENABLE_DCT_ENCRYPTION
+        ret = dct_get_encrypted_variable(&handle, key, (char *)val, &len, DCT_REGION_1);
+#else
         ret = dct_get_variable_new(&handle, key, (char *)val, &len);
+#endif
         dct_close_module(&handle);
         if (DCT_SUCCESS == ret)
         {
@@ -370,7 +468,11 @@ s32 getPref_bool_new(const char *domain, const char *key, u8 *val)
             printf("%s : dct_open_module2(%s) failed with error: %d\n" ,__FUNCTION__, ns, ret);
             goto exit;
         }
+#if CONFIG_ENABLE_DCT_ENCRYPTION
+        ret = dct_get_encrypted_variable(&handle, key, (char *)val, &len, DCT_REGION_2);
+#else
         ret = dct_get_variable_new2(&handle, key, (char *)val, &len);
+#endif
         dct_close_module2(&handle);
         if (DCT_SUCCESS == ret)
         {
@@ -399,7 +501,11 @@ s32 getPref_u32_new(const char *domain, const char *key, u32 *val)
             printf("%s : dct_open_module(%s) failed with error: %d\n" ,__FUNCTION__, ns, ret);
             goto exit;
         }
+#if CONFIG_ENABLE_DCT_ENCRYPTION
+        ret = dct_get_encrypted_variable(&handle, key, (char *)val, &len, DCT_REGION_1);
+#else
         ret = dct_get_variable_new(&handle, key, (char *)val, &len);
+#endif
         dct_close_module(&handle);
         if (DCT_SUCCESS == ret)
         {
@@ -417,7 +523,11 @@ s32 getPref_u32_new(const char *domain, const char *key, u32 *val)
             printf("%s : dct_open_module2(%s) failed with error: %d\n" ,__FUNCTION__, ns, ret);
             goto exit;
         }
+#if CONFIG_ENABLE_DCT_ENCRYPTION
+        ret = dct_get_encrypted_variable(&handle, key, (char *)val, &len, DCT_REGION_2);
+#else
         ret = dct_get_variable_new2(&handle, key, (char *)val, &len);
+#endif
         dct_close_module2(&handle);
         if (DCT_SUCCESS == ret)
         {
@@ -446,7 +556,11 @@ s32 getPref_u64_new(const char *domain, const char *key, u64 *val)
             printf("%s : dct_open_module(%s) failed with error: %d\n" ,__FUNCTION__, ns, ret);
             goto exit;
         }
+#if CONFIG_ENABLE_DCT_ENCRYPTION
+        ret = dct_get_encrypted_variable(&handle, key, (char *)val, &len, DCT_REGION_1);
+#else
         ret = dct_get_variable_new(&handle, key, (char *)val, &len);
+#endif
         dct_close_module(&handle);
         if (DCT_SUCCESS == ret)
         {
@@ -464,7 +578,11 @@ s32 getPref_u64_new(const char *domain, const char *key, u64 *val)
             printf("%s : dct_open_module2(%s) failed with error: %d\n" ,__FUNCTION__, ns, ret);
             goto exit;
         }
+#if CONFIG_ENABLE_DCT_ENCRYPTION
+        ret = dct_get_encrypted_variable(&handle, key, (char *)val, &len, DCT_REGION_2);
+#else
         ret = dct_get_variable_new2(&handle, key, (char *)val, &len);
+#endif
         dct_close_module2(&handle);
         if (DCT_SUCCESS == ret)
         {
@@ -492,7 +610,11 @@ s32 getPref_str_new(const char *domain, const char *key, char * buf, size_t bufS
             printf("%s : dct_open_module(%s) failed with error: %d\n" ,__FUNCTION__, ns, ret);
             goto exit;
         }
+#if CONFIG_ENABLE_DCT_ENCRYPTION
+        ret = dct_get_encrypted_variable(&handle, key, buf, &bufSize, DCT_REGION_1);
+#else
         ret = dct_get_variable_new(&handle, key, buf, &bufSize);
+#endif
         dct_close_module(&handle);
         if (DCT_SUCCESS == ret)
         {
@@ -511,7 +633,11 @@ s32 getPref_str_new(const char *domain, const char *key, char * buf, size_t bufS
             printf("%s : dct_open_module2(%s) failed with error: %d\n" ,__FUNCTION__, ns, ret);
             goto exit;
         }
+#if CONFIG_ENABLE_DCT_ENCRYPTION
+        ret = dct_get_encrypted_variable(&handle, key, buf, &bufSize, DCT_REGION_2);
+#else
         ret = dct_get_variable_new2(&handle, key, buf, &bufSize);
+#endif
         dct_close_module2(&handle);
         if (DCT_SUCCESS == ret)
         {
@@ -540,7 +666,11 @@ s32 getPref_bin_new(const char *domain, const char *key, u8 * buf, size_t bufSiz
             printf("%s : dct_open_module(%s) failed with error: %d\n" ,__FUNCTION__, ns, ret);
             goto exit;
         }
+#if CONFIG_ENABLE_DCT_ENCRYPTION
+        ret = dct_get_encrypted_variable(&handle, key, (char *)buf, &bufSize, DCT_REGION_1);
+#else
         ret = dct_get_variable_new(&handle, key, (char *)buf, &bufSize);
+#endif
         dct_close_module(&handle);
         if (DCT_SUCCESS == ret)
         {
@@ -559,7 +689,11 @@ s32 getPref_bin_new(const char *domain, const char *key, u8 * buf, size_t bufSiz
             printf("%s : dct_open_module2(%s) failed with error: %d\n" ,__FUNCTION__, ns, ret);
             goto exit;
         }
+#if CONFIG_ENABLE_DCT_ENCRYPTION
+        ret = dct_get_encrypted_variable(&handle, key, (char *)buf, &bufSize, DCT_REGION_2);
+#else
         ret = dct_get_variable_new2(&handle, key, (char *)buf, &bufSize);
+#endif
         dct_close_module2(&handle);
         if (DCT_SUCCESS == ret)
         {

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/Makefile.include.gen
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/Makefile.include.gen
@@ -429,6 +429,7 @@ GLOBAL_CFLAGS += -DINET_CONFIG_ENABLE_IPV4=0
 GLOBAL_CFLAGS += -DCONFIG_ENABLE_OTA_REQUESTOR=1
 GLOBAL_CFLAGS += -DCONFIG_ENABLE_AMEBA_FACTORY_DATA=0
 GLOBAL_CFLAGS += -DCONFIG_ENABLE_FACTORY_DATA_ENCRYPTION=0
+GLOBAL_CFLAGS += -DCONFIG_ENABLE_DCT_ENCRYPTION=0
 #*****************************************************************************#
 #                           MATTER END
 #*****************************************************************************#

--- a/project/realtek_amebaD_va0_example/inc/inc_hp/platform_opts.h
+++ b/project/realtek_amebaD_va0_example/inc/inc_hp/platform_opts.h
@@ -114,14 +114,15 @@
 #define MATTER_KVS_BEGIN_ADDR           0x001CC000  // 96K (4*24), DCT begin address of flash, ex: 0x100000 = 1M
 #define MATTER_KVS_MODULE_NUM           13           // max number of module
 #define MATTER_KVS_VARIABLE_NAME_SIZE   32          // max size of the variable name
-#define MATTER_KVS_VARIABLE_VALUE_SIZE  64 + 4      // max size of the variable value
-                                                    // max value number in moudle = 4024 / (32 + 64+4) = 40
+#define MATTER_KVS_VARIABLE_VALUE_SIZE  64          // max size of the variable value
+                                                    // max value number in moudle = floor(4024 / (32 + 64)) = 41
+                                                    
 // MATTER KVS2, for key length large than 64 (Fabric1 ~ FabricF)
 #define MATTER_KVS_BEGIN_ADDR2	        0x003B6000  // 20K (4*5)
 #define MATTER_KVS_MODULE_NUM2          6          // max number of module
 #define MATTER_KVS_VARIABLE_NAME_SIZE2  32          // max size of the variable name
-#define MATTER_KVS_VARIABLE_VALUE_SIZE2 400 + 4    // max size of the variable value
-                                                    // max value number in moudle = 4024 / (32 + 1860+4) = 2
+#define MATTER_KVS_VARIABLE_VALUE_SIZE2 400        // max size of the variable value
+                                                    // max value number in moudle = floor(4024 / (32 + 400)) = 9
 // Matter Factory Data
 #define MATTER_FACTORY_DATA             0x003FF000 
 


### PR DESCRIPTION
- to enable dct encryption, enable `CONFIG_ENABLE_DCT_ENCRYPTION` in `application.is.matter.mk`
- when dct encryption is enabled, call `dct_get_encrypted_variable` and `dct_set_encrypted_variable`
- encryption done using a hardcoded example key
- aes ctr mode is used for encryption, make sure `MBEDTLS_CIPHER_MODE_CTR` is defined