### PR TITLE
[portinglayer] Thermostat port

### DIFF
--- a/component/common/application/matter/core/matter_events.h
+++ b/component/common/application/matter/core/matter_events.h
@@ -16,6 +16,12 @@ struct AppEvent
 
     uint16_t Type;
     chip::app::ConcreteAttributePath path;
-    uint8_t value;
+    union
+    {
+       uint8_t _u8;
+       uint16_t _u16;
+       uint32_t _u32;
+       uint64_t _u64;
+    } value;
     EventHandler mHandler;
 };

--- a/component/common/application/matter/core/matter_interaction.cpp
+++ b/component/common/application/matter/core/matter_interaction.cpp
@@ -145,72 +145,25 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
 {
     AppEvent uplink_event;
     uplink_event.Type = AppEvent::kEventType_Uplink;
-    uplink_event.value = *value;
     uplink_event.path = path;
 
-    switch (path.mClusterId)
+    if (size == 1)
     {
-    case (Clusters::OnOff::Id):
-        uplink_event.mHandler = matter_driver_attribute_update;
-        PostUplinkEvent(&uplink_event);
-        break;
-
-    case (Clusters::LevelControl::Id):
-        uplink_event.mHandler = matter_driver_attribute_update;
-        PostUplinkEvent(&uplink_event);
-        break;
-
-    case (Clusters::Identify::Id):
-        uplink_event.mHandler = matter_driver_attribute_update;
-        PostUplinkEvent(&uplink_event);
-        break;
-
-    default:
-        uplink_event.mHandler = NULL;
-        break;
+        uplink_event.value._u8 = *value;
     }
-}
-
-void matter_interaction_update_cluster(AppEvent * event)
-{
-    switch (event->Type)
+    else if (size == 2)
     {
-        case AppEvent::kEventType_Downlink_OnOff:
-            ChipLogProgress(DeviceLayer, "Writing to OnOff cluster");
-            // write the new on/off value
-            // TODO: we only support endpoint1
-            EmberAfStatus status = Clusters::OnOff::Attributes::OnOff::Set(1, matter_driver_led_get_onoff());
-
-            if (status != EMBER_ZCL_STATUS_SUCCESS)
-            {
-                ChipLogError(DeviceLayer, "Updating on/off cluster failed: %x", status);
-            }
-
-            ChipLogError(DeviceLayer, "Writing to Current Level cluster");
-            // write the new currentlevel value
-            // TODO: we only support endpoint1
-            status = Clusters::LevelControl::Attributes::CurrentLevel::Set(1, matter_driver_led_get_level());
-
-            if (status != EMBER_ZCL_STATUS_SUCCESS)
-            {
-                ChipLogError(DeviceLayer, "Updating level cluster failed: %x", status);
-            }
-            break;
-
-    // TODO: Add more attribute changes
+        memcpy(&uplink_event.value._u16, value, size);
     }
-}
-
-void matter_interaction_onoff_handler(AppEvent * aEvent)
-{
-    if (aEvent->Type != AppEvent::kEventType_Downlink_OnOff)
+    else if (size == 3)
     {
-        ChipLogError(DeviceLayer, "Wrong downlink event handler, should not happen!");
-        return;
+        memcpy(&uplink_event.value._u32, value, size);
+    }
+    else // TODO: check max attribute length
+    {
+        memcpy(&uplink_event.value._u64, value, size);
     }
 
-    matter_driver_led_toggle();
-    chip::DeviceLayer::PlatformMgr().LockChipStack();
-    matter_interaction_update_cluster(aEvent);
-    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+    uplink_event.mHandler = matter_driver_uplink_update_handler;
+    PostUplinkEvent(&uplink_event);
 }

--- a/component/common/application/matter/core/matter_interaction.h
+++ b/component/common/application/matter/core/matter_interaction.h
@@ -7,4 +7,4 @@
 void PostDownlinkEvent(const AppEvent * aEvent);
 CHIP_ERROR matter_interaction_start_downlink(void);
 CHIP_ERROR matter_interaction_start_uplink(void);
-void matter_interaction_onoff_handler(AppEvent *aEvent);
+// void matter_interaction_onoff_handler(AppEvent *aEvent);

--- a/component/common/application/matter/driver/thermostat.cpp
+++ b/component/common/application/matter/driver/thermostat.cpp
@@ -1,0 +1,18 @@
+#include "thermostat.h"
+#include <support/logging/CHIPLogging.h>
+
+void MatterThermostat::Init()
+{
+    // init thermostat driver code
+}
+
+void MatterThermostat::deInit()
+{
+    // deinit thermostat driver code
+}
+
+void MatterThermostat::Do()
+{
+    // implement thermostat action here
+    ChipLogProgress(DeviceLayer, "Thermostat action");
+}

--- a/component/common/application/matter/driver/thermostat.h
+++ b/component/common/application/matter/driver/thermostat.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <platform_stdlib.h>
+
+class MatterThermostat
+{
+public:
+    void Init(void);
+    void deInit(void);
+    void Do(void);
+};

--- a/component/common/application/matter/driver/thermostat_ui.cpp
+++ b/component/common/application/matter/driver/thermostat_ui.cpp
@@ -1,0 +1,60 @@
+#include "thermostat_ui.h"
+#include <support/logging/CHIPLogging.h>
+
+void MatterThermostatUI::Init()
+{
+    // init UI driver code here
+}
+
+void MatterThermostatUI::deInit()
+{
+    // deinit UI driver code here
+}
+
+void MatterThermostatUI::UpdateDisplay()
+{
+    // implement driver code to display values to the UI
+    // printfs here are for example
+    
+    ChipLogProgress(DeviceLayer, "Mode: %d | LocalTemperature: %d | OccupiedCoolingSetpoint: %d | OccupiedHeatingSetpoint: %d", mSystemMode, mLocalTemperature, mOccupiedCoolingSetpoint, mOccupiedHeatingSetpoint);
+}
+
+void MatterThermostatUI::SetLocalTemperature(uint16_t temp)
+{
+    mLocalTemperature = temp;
+}
+
+void MatterThermostatUI::SetOccupiedCoolingSetpoint(uint16_t temp)
+{
+    mOccupiedCoolingSetpoint = temp;
+}
+
+void MatterThermostatUI::SetOccupiedHeatingSetpoint(uint16_t temp)
+{
+    mOccupiedHeatingSetpoint = temp;
+}
+
+void MatterThermostatUI::SetSystemMode(uint8_t mode)
+{
+    mSystemMode = mode;
+}
+
+uint16_t MatterThermostatUI::GetLocalTemperature()
+{
+    return mLocalTemperature;
+}
+
+uint16_t MatterThermostatUI::GetOccupiedCoolingSetpoint()
+{
+    return mOccupiedCoolingSetpoint;
+}
+
+uint16_t MatterThermostatUI::GetOccupiedHeatingSetpoint()
+{
+    return mOccupiedHeatingSetpoint;
+}
+
+uint8_t MatterThermostatUI::GetSystemMode()
+{
+    return mSystemMode;
+}

--- a/component/common/application/matter/driver/thermostat_ui.h
+++ b/component/common/application/matter/driver/thermostat_ui.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <platform_stdlib.h>
+
+class MatterThermostatUI
+{
+public:
+    void Init(void);
+    void deInit(void);
+    void UpdateDisplay(void);
+    void SetLocalTemperature(uint16_t temp);
+    void SetOccupiedCoolingSetpoint(uint16_t temp);
+    void SetOccupiedHeatingSetpoint(uint16_t temp);
+    void SetSystemMode(uint8_t mode);
+    uint16_t GetLocalTemperature(void);
+    uint16_t GetOccupiedCoolingSetpoint(void);
+    uint16_t GetOccupiedHeatingSetpoint(void);
+    uint8_t GetSystemMode(void);
+
+private:
+    uint16_t mLocalTemperature;
+    uint16_t mOccupiedCoolingSetpoint;
+    uint16_t mOccupiedHeatingSetpoint;
+    uint8_t mSystemMode;
+};

--- a/component/common/application/matter/example/light/README.md
+++ b/component/common/application/matter/example/light/README.md
@@ -18,8 +18,10 @@ The initialization of the button sets up an IRQ that is triggered whenever the b
 
 ### Button Press
 Whenever the button is pressed, the interrupt handler will be invoked.
-The interrupt handler will post an event to the downlink queue, which will be received by the interaction handler.
-The interaction handler will be responsible for updating the On/Off attribute of the LED.
+The interrupt handler will post an event to the downlink queue, which will be handled by `matter_driver_downlink_update_handler`.
+
+To implement this, under `matter_drivers.cpp`, setup your GPIO interrupt callback to create and post events to the downlink queue. See `matter_driver_button_callback` for reference.
+When creating the event to post to downlink queue, create a handler function for the event that will update the attributes on the Matter stack. See `matter_driver_downlink_update_handler` for reference.
 
 ### Matter Attribute Change Callback
 Whenever the Matter controller changes the On/Off attribute of the LED, 2 types of callbacks will be invoked:
@@ -27,12 +29,13 @@ Whenever the Matter controller changes the On/Off attribute of the LED, 2 types 
   2. MatterPostAttributeChangeCallback - Toggle the LED after updating the On/Off attribute
 
 These callbacks are defined in `core/matter_interaction.cpp`.
-These callbacks will post an event to the uplink queue, which will be received by the interaction handler.
-The interaction handler will be responsible for toggling the LED.
+These callbacks will post an event to the uplink queue, which will be handled by `matter_driver_uplink_update_handler` in `matter_drivers.cpp`.
+The driver codes will be called to carry out your actions (On/Off LED in this case) depending on the Cluster and Attribute ID received.
+You may add clusters and attributes handling in `matter_driver_uplink_update_handler` if they are not present. 
 
 ## How to build
 
-## Configurations
+### Configurations
 Enable `CONFIG_EXAMPLE_MATTER` and `CONFIG_EXAMPLE_MATTER_LIGHT` in `platform_opts.h`.
 Ensure that `CONFIG_EXAMPLE_MATTER_CHIPTEST` is disabled.
 
@@ -40,7 +43,7 @@ Ensure that `CONFIG_EXAMPLE_MATTER_CHIPTEST` is disabled.
   
     cd connectedhomeip
     source scripts/activate.sh
-
+  
 ### Build Matter Libraries
 
     cd ambd_matter/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp
@@ -55,3 +58,8 @@ Ensure that `CONFIG_EXAMPLE_MATTER_CHIPTEST` is disabled.
     
 ### Flash the Image
 Refer to this [guide](https://github.com/ambiot/ambd_matter/blob/main/tools/AmebaD/Image_Tool_Linux/README.txt) to flash the image with the Linux Image Tool
+
+### Clean Matter Libraries and Firmware
+
+    cd ambd_matter/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp
+    make clean

--- a/component/common/application/matter/example/light/example_matter_light.cpp
+++ b/component/common/application/matter/example/light/example_matter_light.cpp
@@ -13,11 +13,11 @@
 
 static void example_matter_light_task(void *pvParameters)
 {
-    // TODO: error checking
-    // TODO: set default led values
     while(!(wifi_is_up(RTW_STA_INTERFACE) || wifi_is_up(RTW_AP_INTERFACE))) {
-        //waiting for Wifi to be initialized
+        vTaskDelay(500);
     }
+
+    ChipLogProgress(DeviceLayer, "Lighting example!\n");
 
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -25,27 +25,27 @@ static void example_matter_light_task(void *pvParameters)
     //
     err = matter_core_start();
     if (err != CHIP_NO_ERROR)
-        printf("matter_core_start failed!\n");
+        ChipLogProgress(DeviceLayer, "matter_core_start failed!\n");
 
     err = matter_driver_led_init();
     if (err != CHIP_NO_ERROR)
-        printf("matter_driver_led_init failed!\n");
+        ChipLogProgress(DeviceLayer, "matter_driver_led_init failed!\n");
 
     err = matter_driver_led_set_startup_value();
     if (err != CHIP_NO_ERROR)
-        printf("matter_driver_led_set_startup_value failed!\n");
+        ChipLogProgress(DeviceLayer, "matter_driver_led_set_startup_value failed!\n");
 
     err = matter_driver_button_init();
     if (err != CHIP_NO_ERROR)
-        printf("matter_driver_button_init failed!\n");
+        ChipLogProgress(DeviceLayer, "matter_driver_button_init failed!\n");
 
     err = matter_interaction_start_downlink();
     if (err != CHIP_NO_ERROR)
-        printf("matter_interaction_start_downlink failed!\n");
+        ChipLogProgress(DeviceLayer, "matter_interaction_start_downlink failed!\n");
 
     err = matter_interaction_start_uplink();
     if (err != CHIP_NO_ERROR)
-        printf("matter_interaction_start_uplink failed!\n");
+        ChipLogProgress(DeviceLayer, "matter_interaction_start_uplink failed!\n");
 
     while(1);
 }
@@ -53,5 +53,5 @@ static void example_matter_light_task(void *pvParameters)
 extern "C" void example_matter_light(void)
 {
     if(xTaskCreate(example_matter_light_task, ((const char*)"example_matter_task_thread"), 2048, NULL, tskIDLE_PRIORITY + 1, NULL) != pdPASS)
-        printf("\n\r%s xTaskCreate(example_matter_light) failed", __FUNCTION__);
+        ChipLogProgress(DeviceLayer, "\n\r%s xTaskCreate(example_matter_light) failed", __FUNCTION__);
 }

--- a/component/common/application/matter/example/light/matter_drivers.cpp
+++ b/component/common/application/matter/example/light/matter_drivers.cpp
@@ -20,7 +20,8 @@ void matter_driver_button_callback(uint32_t id, gpio_irq_event event)
 {
     AppEvent downlink_event;
     downlink_event.Type     = AppEvent::kEventType_Downlink_OnOff;
-    downlink_event.mHandler = matter_interaction_onoff_handler;
+    downlink_event.value._u8 = (uint8_t) !led.IsTurnedOn(); // toggle
+    downlink_event.mHandler = matter_driver_downlink_update_handler;
     PostDownlinkEvent(&downlink_event);
 }
 
@@ -39,34 +40,6 @@ CHIP_ERROR matter_driver_led_init()
 {
     led.Init(PWM_LED);
     return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR matter_driver_led_set_onoff(uint8_t value)
-{
-    led.Set(value);
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR matter_driver_led_set_brightness(uint8_t value)
-{
-    led.SetBrightness(value);
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR matter_driver_led_toggle()
-{
-    led.Toggle();
-    return CHIP_NO_ERROR;
-}
-
-bool matter_driver_led_get_onoff()
-{
-    return led.IsTurnedOn();
-}
-
-uint8_t matter_driver_led_get_level()
-{
-    return led.GetLevel();
 }
 
 CHIP_ERROR matter_driver_led_set_startup_value()
@@ -95,15 +68,14 @@ CHIP_ERROR matter_driver_led_set_startup_value()
 
     // Set LED to onoff value
     // AppLED.Set(LEDOnOffValue);
-    err = matter_driver_led_set_onoff(LEDOnOffValue);
+    led.Set(LEDOnOffValue);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "Failed to set startup onoff value");
         return CHIP_ERROR_INTERNAL;
     }
     // Set LED to currentlevel value
-    // AppLED.SetBrightness(LEDCurrentLevelValue.Value());
-    err = matter_driver_led_set_brightness(LEDCurrentLevelValue.Value());
+    led.SetBrightness(LEDCurrentLevelValue.Value());
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "Failed to set startup level value");
@@ -113,36 +85,59 @@ CHIP_ERROR matter_driver_led_set_startup_value()
     return err;
 }
 
-void matter_driver_attribute_update(AppEvent *aEvent)
+void matter_driver_uplink_update_handler(AppEvent *aEvent)
 {
-    // get endpoint, cluster, attribute, val
-    // according to above, call the LED api
     chip::app::ConcreteAttributePath path = aEvent->path;
 
-    // TODO: this example only considers endpoint1
+    // this example only considers endpoint1
     VerifyOrExit(aEvent->path.mEndpointId == 1,
                  ChipLogError(DeviceLayer, "Unexpected EndPoint ID: `0x%02x'", path.mEndpointId));
 
     switch(path.mClusterId)
     {
-    case (Clusters::OnOff::Id):
+    case Clusters::OnOff::Id:
         if(path.mAttributeId == Clusters::OnOff::Attributes::OnOff::Id)
         {
-            // led.Set(aEvent->value);
-            matter_driver_led_set_onoff(aEvent->value);
+            led.Set(aEvent->value._u8);
         }
         break;
-    case (Clusters::LevelControl::Id):
+    case Clusters::LevelControl::Id:
         if(path.mAttributeId == Clusters::LevelControl::Attributes::CurrentLevel::Id)
         {
-            // led.SetBrightness(aEvent->value);
-            matter_driver_led_set_brightness(aEvent->value);
+            led.SetBrightness(aEvent->value._u8);
         }
         break;
-    case (Clusters::Identify::Id):
+    case Clusters::Identify::Id:
         break;
     }
 
 exit:
     return;
+}
+
+void matter_driver_downlink_update_handler(AppEvent * event)
+{
+    chip::DeviceLayer::PlatformMgr().LockChipStack();
+    switch (event->Type)
+    {
+        case AppEvent::kEventType_Downlink_OnOff:
+            led.Toggle();
+            ChipLogProgress(DeviceLayer, "Writing to OnOff cluster");
+            EmberAfStatus status = Clusters::OnOff::Attributes::OnOff::Set(1, led.IsTurnedOn());
+
+            if (status != EMBER_ZCL_STATUS_SUCCESS)
+            {
+                ChipLogError(DeviceLayer, "Updating on/off cluster failed: %x", status);
+            }
+
+            ChipLogProgress(DeviceLayer, "Writing to LevelControl cluster");
+            status = Clusters::LevelControl::Attributes::CurrentLevel::Set(1, led.GetLevel());
+
+            if (status != EMBER_ZCL_STATUS_SUCCESS)
+            {
+                ChipLogError(DeviceLayer, "Updating level cluster failed: %x", status);
+            }
+            break;
+    }
+    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 }

--- a/component/common/application/matter/example/light/matter_drivers.h
+++ b/component/common/application/matter/example/light/matter_drivers.h
@@ -3,10 +3,9 @@
 #include "matter_events.h"
 
 #include <platform/CHIPDeviceLayer.h>
+
 CHIP_ERROR matter_driver_button_init(void);
 CHIP_ERROR matter_driver_led_init(void);
-CHIP_ERROR matter_driver_led_toggle(void);
-bool matter_driver_led_get_onoff(void);
-uint8_t matter_driver_led_get_level(void);
 CHIP_ERROR matter_driver_led_set_startup_value(void);
-void matter_driver_attribute_update(AppEvent *aEvent);
+void matter_driver_uplink_update_handler(AppEvent * event);
+void matter_driver_downlink_update_handler(AppEvent *aEvent);

--- a/component/common/application/matter/example/thermostat/README.md
+++ b/component/common/application/matter/example/thermostat/README.md
@@ -1,0 +1,50 @@
+# Thermostat-app Example
+This example is an implementation of the *Thermostat* device type. Peripherals consists of a thermostat and the thermostat user interface itself. Note that these driver codes are meant to be just the skeleton, you should replace them and implement your own.
+
+## How it works
+We support bidirectional exchanges of attrubute updates (see `light` example) but this example will only make use of uplink updates.
+Feel free to create downlink updates by posting events to the downlink queue (again, see `light` example).
+
+### Peripheral Initialization
+Both the initializations of the thermostat and the thermostat UI are handled in `matter_drivers.cpp`.
+
+### Matter Attribute Change Callback
+Whenever the Matter controller changes the attribute of the Thermostat cluster, 2 types of callbacks will be invoked:
+  1. MatterPreAttributeChangeCallback - Do action before updating the On/Off attribute (TBD)
+  2. MatterPostAttributeChangeCallback - Do action after updating the On/Off attribute
+
+These callbacks are defined in `core/matter_interaction.cpp`.
+These callbacks will post an event to the uplink queue, which will be handled by `matter_driver_uplink_update_handler` in `matter_drivers.cpp`.
+The driver codes will be called to carry out your actions depending on the Cluster and Attribute ID received.
+You may add clusters and attributes handling in `matter_driver_uplink_update_handler` if they are not present. 
+
+## How to build
+
+### Configurations
+Enable `CONFIG_EXAMPLE_MATTER` and `CONFIG_EXAMPLE_MATTER_THERMOSTAT` in `platform_opts.h`.
+Ensure that `CONFIG_EXAMPLE_MATTER_CHIPTEST` is disabled.
+
+### Setup the Build Environment
+  
+    cd connectedhomeip
+    source scripts/activate.sh
+
+### Build Matter Libraries
+
+    cd ambd_matter/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp
+    make -C asdk thermostat_port
+    
+### Build the Final Firmware
+
+    cd ambd_matter/project/realtek_amebaD_va0_example/GCC-RELEASE/project_lp
+    make all
+    cd ambd_matter/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp
+    make all
+    
+### Flash the Image
+Refer to this [guide](https://github.com/ambiot/ambd_matter/blob/main/tools/AmebaD/Image_Tool_Linux/README.txt) to flash the image with the Linux Image Tool
+
+### Clean Matter Libraries
+
+    cd ambd_matter/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp
+    make clean

--- a/component/common/application/matter/example/thermostat/example_matter_thermostat.cpp
+++ b/component/common/application/matter/example/thermostat/example_matter_thermostat.cpp
@@ -1,0 +1,57 @@
+#include "FreeRTOS.h"
+#include "task.h"
+#include "platform/platform_stdlib.h"
+#include "basic_types.h"
+#include "platform_opts.h"
+#include "section_config.h"
+#include "wifi_constants.h"
+#include "wifi/wifi_conf.h"
+#include "chip_porting.h"
+#include "matter_core.h"
+#include "matter_drivers.h"
+#include "matter_interaction.h"
+
+static void example_matter_thermostat_task(void *pvParameters)
+{
+    while(!(wifi_is_up(RTW_STA_INTERFACE) || wifi_is_up(RTW_AP_INTERFACE))) {
+        vTaskDelay(500);
+    }
+
+    ChipLogProgress(DeviceLayer, "Thermostat example!\n");
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    initPref();     // init NVS
+    //
+    err = matter_core_start();
+    if (err != CHIP_NO_ERROR)
+        ChipLogProgress(DeviceLayer, "matter_core_start failed!\n");
+
+    err = matter_driver_thermostat_init();
+    if (err != CHIP_NO_ERROR)
+        ChipLogProgress(DeviceLayer, "matter_driver_thermostat_init failed!\n");
+
+    err = matter_driver_thermostat_ui_init();
+    if (err != CHIP_NO_ERROR)
+        ChipLogProgress(DeviceLayer, "matter_driver_thermostat_ui_init failed!\n");
+
+    err = matter_driver_thermostat_ui_set_startup_value();
+    if (err != CHIP_NO_ERROR)
+        ChipLogProgress(DeviceLayer, "matter_driver_thermostat_ui_set_startup_value failed!\n");
+
+    err = matter_interaction_start_downlink();
+    if (err != CHIP_NO_ERROR)
+        ChipLogProgress(DeviceLayer, "matter_interaction_start_downlink failed!\n");
+
+    err = matter_interaction_start_uplink();
+    if (err != CHIP_NO_ERROR)
+        ChipLogProgress(DeviceLayer, "matter_interaction_start_uplink failed!\n");
+
+    while(1);
+}
+
+extern "C" void example_matter_thermostat(void)
+{
+    if(xTaskCreate(example_matter_thermostat_task, ((const char*)"example_matter_task_thread"), 2048, NULL, tskIDLE_PRIORITY + 1, NULL) != pdPASS)
+        ChipLogProgress(DeviceLayer, "\n\r%s xTaskCreate(example_matter_thermostat) failed", __FUNCTION__);
+}

--- a/component/common/application/matter/example/thermostat/example_matter_thermostat.h
+++ b/component/common/application/matter/example/thermostat/example_matter_thermostat.h
@@ -1,0 +1,6 @@
+#ifndef EXAMPLE_MATTER_LIGHT_H
+#define EXAMPLE_MATTER_LIGHT_H
+
+void example_matter_task(void);
+
+#endif /* EXAMPLE_MATTER_LIGHT_H */

--- a/component/common/application/matter/example/thermostat/matter_drivers.cpp
+++ b/component/common/application/matter/example/thermostat/matter_drivers.cpp
@@ -1,0 +1,108 @@
+#include "matter_drivers.h"
+#include "matter_interaction.h"
+#include "thermostat.h"
+#include "thermostat_ui.h"
+#include "gpio_irq_api.h"
+
+#include <app-common/zap-generated/attribute-type.h>
+#include <app-common/zap-generated/attributes/Accessors.h>
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app-common/zap-generated/ids/Clusters.h>
+
+using namespace ::chip::app;
+
+MatterThermostatUI ui;
+MatterThermostat thermostat;
+
+CHIP_ERROR matter_driver_thermostat_init()
+{
+    thermostat.Init();
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR matter_driver_thermostat_ui_init()
+{
+    ui.Init();
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR matter_driver_thermostat_ui_set_startup_value()
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    EmberAfStatus getstatus;
+    DataModel::Nullable<int16_t> temp;
+    int16_t OccupiedCoolingSetpoint;
+    int16_t OccupiedHeatingSetpoint;
+    uint8_t SystemMode;
+
+    chip::DeviceLayer::PlatformMgr().LockChipStack();
+    getstatus = Clusters::Thermostat::Attributes::LocalTemperature::Get(1, temp);
+    VerifyOrExit(getstatus == EMBER_ZCL_STATUS_SUCCESS, err = CHIP_ERROR_INTERNAL);
+    getstatus = Clusters::Thermostat::Attributes::OccupiedCoolingSetpoint::Get(1, &OccupiedCoolingSetpoint);
+    VerifyOrExit(getstatus == EMBER_ZCL_STATUS_SUCCESS, err = CHIP_ERROR_INTERNAL);
+    getstatus = Clusters::Thermostat::Attributes::OccupiedHeatingSetpoint::Get(1, &OccupiedHeatingSetpoint);
+    VerifyOrExit(getstatus == EMBER_ZCL_STATUS_SUCCESS, err = CHIP_ERROR_INTERNAL);
+    getstatus = Clusters::Thermostat::Attributes::SystemMode::Get(1, &SystemMode);
+    VerifyOrExit(getstatus == EMBER_ZCL_STATUS_SUCCESS, err = CHIP_ERROR_INTERNAL);
+    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+
+    if (temp.IsNull())
+        ui.SetLocalTemperature(0);
+    else
+        ui.SetLocalTemperature(temp.Value());
+
+    ui.SetOccupiedCoolingSetpoint(OccupiedCoolingSetpoint);
+    ui.SetOccupiedHeatingSetpoint(OccupiedHeatingSetpoint);
+    ui.SetSystemMode(SystemMode);
+
+    ui.UpdateDisplay();
+
+exit:
+    return err;
+}
+
+void matter_driver_uplink_update_handler(AppEvent *aEvent)
+{
+    chip::app::ConcreteAttributePath path = aEvent->path;
+
+    VerifyOrExit(aEvent->path.mEndpointId == 1,
+                 ChipLogError(DeviceLayer, "Unexpected EndPoint ID: `0x%02x'", path.mEndpointId));
+
+    switch(path.mClusterId)
+    {
+    case Clusters::Identify::Id:
+        break;
+    case Clusters::Thermostat::Id:
+        if(path.mAttributeId == Clusters::Thermostat::Attributes::LocalTemperature::Id)
+        {
+            ui.SetLocalTemperature(aEvent->value._u16);
+            thermostat.Do();
+        }
+        if(path.mAttributeId == Clusters::Thermostat::Attributes::OccupiedCoolingSetpoint::Id)
+        {
+            ui.SetOccupiedCoolingSetpoint(aEvent->value._u16);
+            thermostat.Do();
+        }
+        if(path.mAttributeId == Clusters::Thermostat::Attributes::OccupiedHeatingSetpoint::Id)
+        {
+            ui.SetOccupiedHeatingSetpoint(aEvent->value._u16);
+            thermostat.Do();
+        }
+        if(path.mAttributeId == Clusters::Thermostat::Attributes::SystemMode::Id)
+        {
+            ui.SetSystemMode(aEvent->value._u8);
+            thermostat.Do();
+        }
+        ui.UpdateDisplay();
+        break;
+    case Clusters::Scenes::Id:
+        break;
+    case Clusters::RelativeHumidityMeasurement::Id:
+        break;
+    case Clusters::FanControl::Id:
+        break;
+    }
+
+exit:
+    return;
+}

--- a/component/common/application/matter/example/thermostat/matter_drivers.h
+++ b/component/common/application/matter/example/thermostat/matter_drivers.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "matter_events.h"
+
+#include <platform/CHIPDeviceLayer.h>
+CHIP_ERROR matter_driver_thermostat_init(void);
+CHIP_ERROR matter_driver_thermostat_ui_init(void);
+CHIP_ERROR matter_driver_thermostat_ui_set_startup_value(void);
+void matter_driver_uplink_update_handler(AppEvent *aEvent);

--- a/component/common/example/example_entry.c
+++ b/component/common/example/example_entry.c
@@ -940,8 +940,9 @@ example_hilink();
 #if defined(CONFIG_EXAMPLE_MATTER_CHIPTEST) && (CONFIG_EXAMPLE_MATTER_CHIPTEST == 1)
     example_matter_task();
 #elif defined(CONFIG_EXAMPLE_MATTER_LIGHT) && (CONFIG_EXAMPLE_MATTER_LIGHT == 1)
-    // extern void example_matter_light();
     example_matter_light();
+#elif defined(CONFIG_EXAMPLE_MATTER_THERMOSTAT) && (CONFIG_EXAMPLE_MATTER_THERMOSTAT == 1)
+    example_matter_thermostat();
 #endif
 #endif
 

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/Makefile
@@ -177,6 +177,7 @@ bootloader: build_target_folder copy_ld_img1 check_toolchain build_info.h make_s
 all_clusters: build_target_folder copy_ld_img2 check_toolchain build_info.h make_subdirs_lib_all_clusters
 light: build_target_folder copy_ld_img2 check_toolchain build_info.h make_subdirs_lib_lighting
 light_port: build_target_folder copy_ld_img2 check_toolchain build_info.h make_subdirs_lib_lighting_port
+thermostat_port: build_target_folder copy_ld_img2 check_toolchain build_info.h make_subdirs_lib_thermostat_port
 
 #*****************************************************************************#
 #                      RULES TO CREATE DIRECTORY                              #
@@ -261,6 +262,17 @@ make_subdirs_lib_lighting_port:
 	python3 $(MATTER_TOOLDIR)/codegen_helpers/parse_clusters.py --cluster_file $(CHIPDIR)/examples/lighting-app/ameba/build/chip/codegen/cluster-file.txt --chip_path $(CHIPDIR) && \
 	make -C make/chip/lighting_app all
 	make -C make/chip_main/lighting_port all
+
+make_subdirs_lib_thermostat_port:
+	@ rm -f $(RAM_OBJS_LIST)
+	mkdir -p $(CHIPDIR)/examples/thermostat/ameba/build/chip/codegen/zap-generated && \
+	python3 $(CHIPDIR)/scripts/tools/zap/generate.py --no-prettify-output --templates src/app/zap-templates/matter-idl.json --output-dir examples/thermostat/ameba/build/chip/codegen/zap-generated examples/thermostat/thermostat-common/thermostat.zap && \
+	python3 $(CHIPDIR)/scripts/tools/zap/generate.py --no-prettify-output --templates src/app/zap-templates/app-templates.json --output-dir examples/thermostat/ameba/build/chip/codegen/zap-generated examples/thermostat/thermostat-common/thermostat.zap && \
+	python3 $(CHIPDIR)/scripts/codegen.py --generator cpp-app --output-dir $(CHIPDIR)/examples/thermostat/ameba/build/chip/codegen --expected-outputs $(MATTER_TOOLDIR)/codegen_helpers/expected.outputs $(CHIPDIR)/examples/thermostat/thermostat-common/thermostat.matter && \
+	python3 $(CHIPDIR)/src/app/zap_cluster_list.py --zap_file $(CHIPDIR)/examples/thermostat/thermostat-common/thermostat.zap > $(CHIPDIR)/examples/thermostat/ameba/build/chip/codegen/cluster-file.txt && \
+	python3 $(MATTER_TOOLDIR)/codegen_helpers/parse_clusters.py --cluster_file $(CHIPDIR)/examples/thermostat/ameba/build/chip/codegen/cluster-file.txt --chip_path $(CHIPDIR) && \
+	make -C make/chip/thermostat_app all
+	make -C make/chip_main/thermostat_port all
 
 #*****************************************************************************#
 #                      RULES TO LINKER IMAGE                                  #

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip/Makefile
@@ -35,5 +35,6 @@ CORE_TARGETS: $(OBJS)
 clean: CLEAN_OBJS 
 	make -C all_clusters_app clean
 	make -C lighting_app clean
+	make -C thermostat_app clean
 
 -include $(DEPS)

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip/thermostat_app/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip/thermostat_app/Makefile
@@ -1,0 +1,72 @@
+include $(MAKE_INCLUDE_GEN)
+
+.PHONY: all clean
+
+#*****************************************************************************#
+#                               VARIABLES	                              #
+#*****************************************************************************#
+SHELL := /bin/bash
+
+OUTPUT_DIR = $(CHIPDIR)/examples/thermostat/ameba/build/chip
+
+#*****************************************************************************#
+#                               CFLAGS                                        #
+#*****************************************************************************#
+
+GLOBAL_CFLAGS += -DCHIP_PROJECT=1
+
+CHIP_CFLAGS = $(GLOBAL_CFLAGS)
+CHIP_CXXFLAGS += $(GLOBAL_CFLAGS)
+
+#*****************************************************************************#
+#                               Include FILE LIST                             #
+#*****************************************************************************#
+
+GLOBAL_CFLAGS += -I$(CHIPDIR)/config/ameba
+GLOBAL_CFLAGS += -I$(CHIPDIR)/src/include/platform/Ameba
+GLOBAL_CFLAGS += -I$(CHIPDIR)/src/include
+GLOBAL_CFLAGS += -I$(CHIPDIR)/src/lib
+GLOBAL_CFLAGS += -I$(CHIPDIR)/src
+GLOBAL_CFLAGS += -I$(CHIPDIR)/src/system
+GLOBAL_CFLAGS += -I$(CHIPDIR)/src/app
+GLOBAL_CFLAGS += -I$(CHIPDIR)/third_party/nlassert/repo/include
+GLOBAL_CFLAGS += -I$(CHIPDIR)/third_party/nlio/repo/include
+GLOBAL_CFLAGS += -I$(CHIPDIR)/third_party/nlunit-test/repo/src
+
+GLOBAL_CFLAGS += -I$(BASEDIR)/component/common/bluetooth/realtek/sdk/example/bt_matter_adapter
+
+#*****************************************************************************#
+#                        RULES TO GENERATE TARGETS                            #
+#*****************************************************************************#
+
+# Define the Rules to build the core targets
+all: GENERATE_NINJA
+
+GENERATE_NINJA:
+	echo "INSTALL CHIP..." && \
+	mkdir -p $(OUTPUT_DIR) && \
+	echo                                   > $(OUTPUT_DIR)/args.gn && \
+	echo "import(\"//args.gni\")"          >> $(OUTPUT_DIR)/args.gn && \
+	echo target_cflags_c  = [$(foreach word,$(CHIP_CFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'  >> $(OUTPUT_DIR)/args.gn && \
+	echo target_cflags_cc = [$(foreach word,$(CHIP_CXXFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'   >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_ar = \"arm-none-eabi-ar\"    >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_cc = \"arm-none-eabi-gcc\"   >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_cxx = \"arm-none-eabi-c++\"  >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_cpu = \"ameba\"               >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_inet_config_enable_ipv4 = "false" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_enable_ota_requestor = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
+	cd $(CHIPDIR) && PW_ENVSETUP_QUIET=1 . scripts/activate.sh && \
+	mkdir -p $(CHIPDIR)/config/ameba/components/chip && \
+	cd $(CHIPDIR)/config/ameba/components/chip && gn gen --check --fail-on-unused-args $(CHIPDIR)/examples/thermostat/ameba/build/chip && \
+	cd $(CHIPDIR)/config/ameba/components/chip ; ninja -C $(CHIPDIR)/examples/thermostat/ameba/build/chip :ameba && \
+	cp -f $(OUTPUT_DIR)/lib/* $(ROOTDIR)/lib/application/
+
+#*****************************************************************************#
+#              CLEAN GENERATED FILES                                          #
+#*****************************************************************************#
+clean:
+	echo "RM $(OUTPUT_DIR)"
+	rm -rf $(OUTPUT_DIR)
+
+-include $(DEPS)

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/Makefile
@@ -35,5 +35,6 @@ clean: CLEAN_OBJS
 	make -C all_clusters_app clean
 	make -C lighting_app clean
 	make -C lighting_port clean
+	make -C thermostat_port clean
 
 -include $(DEPS)

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/thermostat_port/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/thermostat_port/Makefile
@@ -26,24 +26,24 @@ include $(MAKE_INCLUDE_GEN)
 #*****************************************************************************#
 #                               VARIABLES	                              #
 #*****************************************************************************#
-OUTPUT_DIR = $(CHIPDIR)/examples/lighting-app/ameba/build/chip
+OUTPUT_DIR = $(CHIPDIR)/examples/thermostat/ameba/build/chip
 CODEGEN_DIR = $(OUTPUT_DIR)/codegen
 
 DIR = $(SRCDIR)
 DIR += $(CHIPDIR)/src/app
 DIR += $(CHIPDIR)/src/app/server
 DIR += $(CHIPDIR)/src/lib/dnssd/minimal_mdns/responders
-DIR += $(CHIPDIR)/examples/lighting-app/lighting-common
-DIR += $(CHIPDIR)/examples/lighting-app/ameba/main
+DIR += $(CHIPDIR)/examples/thermostat/thermostat-common
+DIR += $(CHIPDIR)/examples/thermostat/ameba/main
 DIR += $(CHIPDIR)/examples/platform/ameba/ota
 DIR += $(CHIPDIR)/examples/platform/ameba/route_hook
 DIR += $(CHIPDIR)/examples/providers
-DIR += $(CHIPDIR)/zzz_generated/lighting-app/zap-generated
+DIR += $(CHIPDIR)/zzz_generated/thermostat/zap-generated
 DIR += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated
 DIR += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/attributes
 DIR += $(BASEDIR)/component/common/application/matter/core
 DIR += $(BASEDIR)/component/common/application/matter/driver
-DIR += $(BASEDIR)/component/common/application/matter/example/light
+DIR += $(BASEDIR)/component/common/application/matter/example/thermostat
 DIR += $(BASEDIR)/tools/matter/codegen_helpers/gen/app
 DIR += $(CODEGEN_DIR)/app
 DIR += $(CODEGEN_DIR)/zap-generated
@@ -65,16 +65,16 @@ IFLAGS += -I$(BASEDIR)/component/common/application/matter/common/mbedtls
 IFLAGS += -I$(BASEDIR)/component/common/application/matter/common/port
 IFLAGS += -I$(BASEDIR)/component/common/application/matter/core
 IFLAGS += -I$(BASEDIR)/component/common/application/matter/driver
-IFLAGS += -I$(BASEDIR)/component/common/application/matter/example/light
+IFLAGS += -I$(BASEDIR)/component/common/application/matter/example/thermostat
 
 #IFLAGS = -I$(DIR)./
 IFLAGS += -I$(CHIPDIR)/zzz_generated
 IFLAGS += -I$(CHIPDIR)/zzz_generated/app-common
-IFLAGS += -I$(CHIPDIR)/zzz_generated/lighting-app
-IFLAGS += -I$(CHIPDIR)/zzz_generated/lighting-app/zap-generated
-IFLAGS += -I$(CHIPDIR)/examples/lighting-app/lighting-common
-IFLAGS += -I$(CHIPDIR)/examples/lighting-app/ameba/main/include
-IFLAGS += -I$(CHIPDIR)/examples/lighting-app/ameba/build/chip/gen/include
+IFLAGS += -I$(CHIPDIR)/zzz_generated/thermostat
+IFLAGS += -I$(CHIPDIR)/zzz_generated/thermostat/zap-generated
+IFLAGS += -I$(CHIPDIR)/examples/thermostat/thermostat-common
+IFLAGS += -I$(CHIPDIR)/examples/thermostat/ameba/main/include
+IFLAGS += -I$(CHIPDIR)/examples/thermostat/ameba/build/chip/gen/include
 IFLAGS += -I$(CHIPDIR)/examples/platform/ameba
 IFLAGS += -I$(CHIPDIR)/examples/providers
 IFLAGS += -I$(CHIPDIR)/src/include/
@@ -129,13 +129,14 @@ CPPSRC += $(CHIPDIR)/examples/providers/DeviceInfoProviderImpl.cpp
 CSRC += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_hook.c
 CSRC += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_table.c
 
-# Custom light-app src files with porting layer
+# Custom thermostat-app src files with porting layer
 CPPSRC += $(BASEDIR)/component/common/application/matter/core/matter_core.cpp
 CPPSRC += $(BASEDIR)/component/common/application/matter/core/matter_interaction.cpp
 CPPSRC += $(BASEDIR)/component/common/application/matter/core/matter_ota.cpp
-CPPSRC += $(BASEDIR)/component/common/application/matter/driver/led_driver.cpp
-CPPSRC += $(BASEDIR)/component/common/application/matter/example/light/example_matter_light.cpp
-CPPSRC += $(BASEDIR)/component/common/application/matter/example/light/matter_drivers.cpp
+CPPSRC += $(BASEDIR)/component/common/application/matter/driver/thermostat.cpp
+CPPSRC += $(BASEDIR)/component/common/application/matter/driver/thermostat_ui.cpp
+CPPSRC += $(BASEDIR)/component/common/application/matter/example/thermostat/example_matter_thermostat.cpp
+CPPSRC += $(BASEDIR)/component/common/application/matter/example/thermostat/matter_drivers.cpp
 
 #*****************************************************************************#
 #                               Object FILE LIST                              #
@@ -172,11 +173,11 @@ $(STATIC_LIB):$(OBJS)
 #              CLEAN GENERATED FILES                                          #
 #*****************************************************************************#
 clean:
-	rm -f $(ROOTDIR)/make/chip_main/lighting_port/*.o
-	rm -f $(ROOTDIR)/make/chip_main/lighting_port/*.i
-	rm -f $(ROOTDIR)/make/chip_main/lighting_port/*.s
-	rm -f $(ROOTDIR)/make/chip_main/lighting_port/*.d
-	rm -f $(ROOTDIR)/make/chip_main/lighting_port/*.ii
-	rm -f $(ROOTDIR)/make/chip_main/lighting_port/*.su
+	rm -f $(ROOTDIR)/make/chip_main/thermostat_port/*.o
+	rm -f $(ROOTDIR)/make/chip_main/thermostat_port/*.i
+	rm -f $(ROOTDIR)/make/chip_main/thermostat_port/*.s
+	rm -f $(ROOTDIR)/make/chip_main/thermostat_port/*.d
+	rm -f $(ROOTDIR)/make/chip_main/thermostat_port/*.ii
+	rm -f $(ROOTDIR)/make/chip_main/thermostat_port/*.su
 
 -include $(DEPS)

--- a/project/realtek_amebaD_va0_example/inc/inc_hp/platform_opts.h
+++ b/project/realtek_amebaD_va0_example/inc/inc_hp/platform_opts.h
@@ -761,5 +761,6 @@ in lwip_opt.h for support uart adapter*/
 #define CONFIG_EXAMPLE_MATTER 1
 #define CONFIG_EXAMPLE_MATTER_CHIPTEST 1
 #define CONFIG_EXAMPLE_MATTER_LIGHT 0
+#define CONFIG_EXAMPLE_MATTER_THERMOSTAT 0
 
 #endif


### PR DESCRIPTION
- add thermostat example on top of porting layer
- add thermostat and thermostat ui skeleton drivers
- update `matter_interactions.cpp` function names for clarity
- use union for value inside of `AppEvent` to account for different value sizes
- update `matter_drivers.cpp` in porting layer light example
- update readmes
- cleanups for porting layer light example