### PR TITLE
[wifi] fix wifi scan and store wifi dct

### DIFF
--- a/component/common/api/wifi/wifi_conf.c
+++ b/component/common/api/wifi/wifi_conf.c
@@ -14,10 +14,6 @@
 #include <osdep_service.h>
 #include <device_lock.h>
 
-#if CONFIG_EXAMPLE_MATTER
-#include "chip_porting.h"
-#endif
-
 #if CONFIG_EXAMPLE_WLAN_FAST_CONNECT || (defined(CONFIG_JD_SMART) && CONFIG_JD_SMART)
 #include "wlan_fast_connect/example_wlan_fast_connect.h"
 #if defined(CONFIG_FAST_DHCP) && CONFIG_FAST_DHCP
@@ -889,15 +885,6 @@ int wifi_connect(
 	}
 
 	result = RTW_SUCCESS;
-
-#if CONFIG_EXAMPLE_MATTER
-    // these keys need to match exactly the same keys in matter sdk, AmebaUtils.cpp
-    const char kWiFiSSIDKeyName[]        = "wifi-ssid";
-    const char kWiFiCredentialsKeyName[] = "wifi-pass";
-
-    setPref_new(kWiFiSSIDKeyName, kWiFiSSIDKeyName, (uint8_t*) ssid, ssid_len);
-    setPref_new(kWiFiCredentialsKeyName, kWiFiCredentialsKeyName, (uint8_t*) password, password_len);
-#endif
 
 #if CONFIG_LWIP_LAYER
 #if defined(CONFIG_MBED_ENABLED) || defined(CONFIG_PLATFOMR_CUSTOMER_RTOS)

--- a/component/common/application/matter/common/port/matter_wifis.c
+++ b/component/common/application/matter/common/port/matter_wifis.c
@@ -148,9 +148,9 @@ void matter_scan_networks_with_ssid(const unsigned char *ssid, size_t length)
     }
 }
 
-void matter_get_scan_results(rtw_scan_result_t *result_buf, uint8_t scanned_num)
+rtw_scan_result_t *matter_get_scan_results()
 {
-    memcpy(result_buf, matter_userdata, sizeof(rtw_scan_result_t) * scanned_num);
+    return matter_userdata;
 }
 
 static int matter_find_ap_from_scan_buf(char*buf, int buflen, char *target_ssid, void *user_data)
@@ -253,6 +253,11 @@ int matter_wifi_connect(
     err = wifi_connect(ssid, security_type, password, strlen(ssid), strlen(password), key_id, NULL);
 
     return err;
+}
+
+int matter_get_sta_wifi_info(rtw_wifi_setting_t *pSetting)
+{
+    return wifi_get_setting((u8*)WLAN0_NAME, pSetting);
 }
 
 int matter_wifi_disconnect(void)

--- a/component/common/application/matter/common/port/matter_wifis.h
+++ b/component/common/application/matter/common/port/matter_wifis.h
@@ -25,7 +25,7 @@ typedef int (*chip_connmgr_callback)(void *object);
 void chip_connmgr_set_callback_func(chip_connmgr_callback p, void *data);
 void matter_scan_networks(void);
 void matter_scan_networks_with_ssid(const unsigned char *ssid, size_t length);
-void matter_get_scan_results(rtw_scan_result_t *result_buf, uint8_t scanned_num);
+rtw_scan_result_t *matter_get_scan_results();
 int matter_wifi_connect(
     char              *ssid,
     rtw_security_t    security_type,
@@ -34,6 +34,7 @@ int matter_wifi_connect(
     int               password_len,
     int               key_id,
     void              *semaphore);
+int matter_get_sta_wifi_info(rtw_wifi_setting_t *pSetting);
 int matter_wifi_disconnect(void);
 int matter_wifi_on(rtw_mode_t mode);
 int matter_wifi_set_mode(rtw_mode_t mode);


### PR DESCRIPTION
* remove storing wifi into dct during wifi_connect and add new API for matter to get wifi ssid and password
* return pointer to matter_userdata