### PR TITLE
[lwip] Fix ipv6 address issue

### DIFF
--- a/component/common/api/lwip_netconf.c
+++ b/component/common/api/lwip_netconf.c
@@ -677,8 +677,10 @@ uint8_t LwIP_DHCP6(uint8_t idx, uint8_t dhcp6_state)
 
 				/* Read the new IPv6 address */
 				ipv6_global = LwIP_GetIPv6_global(pnetif);
+                ip6_addr_t zero_address;
+				ip6_addr_set_any(&zero_address);
 
-				if(*ipv6_global!=0){
+                if(!ip6_addr_cmp(&zero_address, netif_ip6_addr(pnetif, 1))){
 
 					DHCP6_state = DHCP6_ADDRESS_ASSIGNED;
 

--- a/component/common/network/lwip/lwip_v2.1.2/src/core/ipv6/nd6.c
+++ b/component/common/network/lwip/lwip_v2.1.2/src/core/ipv6/nd6.c
@@ -1161,17 +1161,32 @@ nd6_tmr(void)
   if (!nd6_tmr_rs_reduction) {
     nd6_tmr_rs_reduction = (ND6_RTR_SOLICITATION_INTERVAL / ND6_TMR_INTERVAL) - 1;
     NETIF_FOREACH(netif) {
+      /* Added by Realtek start*/
+      ip6_addr_t zero_address;
+      ip6_addr_set_any(&zero_address);
+      /* Added by Realtek end*/
       if ((netif->rs_count > 0) && netif_is_up(netif) &&
           netif_is_link_up(netif) &&
           !ip6_addr_isinvalid(netif_ip6_addr_state(netif, 0)) &&
           !ip6_addr_isduplicated(netif_ip6_addr_state(netif, 0))) {
         if (nd6_send_rs(netif) == ERR_OK) {
           netif->rs_count--;
+          /* Added by Realtek start*/
           if (netif->rs_count == 0){
             netif->rs_timeout = 1;
           }
+          /* Added by Realtek end*/
         }
       }
+      /* Added by Realtek start */
+      else if((netif->rs_count == 0) && netif_is_up(netif) &&
+        netif_is_link_up(netif) &&
+        !ip6_addr_isinvalid(netif_ip6_addr_state(netif, 0)) &&
+        !ip6_addr_isduplicated(netif_ip6_addr_state(netif, 0))
+        && (ip6_addr_cmp(&zero_address, netif_ip6_addr(netif, 1)))) {
+          netif->rs_timeout = 1;
+      }
+      /* Added by Realtek end */
     }
   } else {
     nd6_tmr_rs_reduction--;


### PR DESCRIPTION
* Fix potential ipv6 hang issue -. If rs_count is set to zero in nd6_input(), rs_timeout will always be zero and doesn't trigger timeout. -. Add condition to prevent hang issue

* Fix IPv6 Address starting with zero -. According to RFC 5156, special IPv6 addresses with IPv4-Mapped Addresses, will use zero as the starting bytes of the address. e.g. ::FFFF:0:0/96. -. Fix LwIP_DHCP6() unable to successfully obtain IPv6 Address