### PR TITLE
[factorydata] return when factorydata length is more than 4kb

### DIFF
--- a/component/common/application/matter/common/port/matter_utils.c
+++ b/component/common/application/matter/common/port/matter_utils.c
@@ -250,6 +250,14 @@ int32_t ReadFactory(uint8_t *buffer, uint16_t *pfactorydata_len)
     ret = flash_stream_read(&flash, address, length_bytes, pfactorydata_len);
     device_mutex_unlock(RT_DEV_LOCK_FLASH);
 
+    // Check if factory data length is more than 4096
+    // Which indicates that factory data is not flashed
+    // Return to prevent reading from non-existent address
+    if(*pfactorydata_len > 4096)
+    {
+        return -1;
+    }
+
     // +2 offset to read the FactoryData
     device_mutex_lock(RT_DEV_LOCK_FLASH);
     ret = flash_stream_read(&flash, address+2, *pfactorydata_len, buffer);


### PR DESCRIPTION
- this means factorydata is not flashed
- return to prevent reading from non-existent address