### PR TITLE
[lwip] increase bufsize to 1500

### DIFF
--- a/component/common/api/network/include/lwipopts.h
+++ b/component/common/api/network/include/lwipopts.h
@@ -109,7 +109,7 @@ a lot of data that needs to be copied, this should be set high. */
 #endif
 
 /* PBUF_POOL_BUFSIZE: the size of each pbuf in the pbuf pool. */
-#define PBUF_POOL_BUFSIZE       1280
+#define PBUF_POOL_BUFSIZE       1500
 
 
 /* ---------- TCP options ---------- */


### PR DESCRIPTION
- when connected to ecosystems, sometimes might receive packet buffer of size >1400
- results in "no memory error"