### PR TITLE
[portinglayer] add a str field in the union for string data

### DIFF
--- a/component/common/application/matter/core/matter_events.h
+++ b/component/common/application/matter/core/matter_events.h
@@ -22,6 +22,7 @@ struct AppEvent
        uint16_t _u16;
        uint32_t _u32;
        uint64_t _u64;
+       char _str[256];
     } value;
     EventHandler mHandler;
 };

--- a/component/common/application/matter/core/matter_interaction.cpp
+++ b/component/common/application/matter/core/matter_interaction.cpp
@@ -161,7 +161,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
     }
     else if (size <= 8)
     {
-        memcpy(&uplink_event.value._u32, value, size);
+        memcpy(&uplink_event.value._u64, value, size);
     }
     else if (size <= 256) // TODO: check max attribute length
     {


### PR DESCRIPTION
- set maximum size of data to be 256 for string values
- the increase in ram usage is not a problem as the event will be cleared after `xQueueReceive` successfully received and handled the data

