### PR TITLE
[portinglayer] [build] implement error mapping and add files to build

### DIFF
--- a/component/common/application/matter/common/port/chip_porting.h
+++ b/component/common/application/matter/common/port/chip_porting.h
@@ -17,6 +17,7 @@ extern "C" {
 #include <stddef.h> /* for size_t */
 #include <stdarg.h>
 #include <platform_opts_bt.h>
+#include <dct.h>
 
 #if CONFIG_BT_MATTER_ADAPTER
 /** @brief  Config local address type: 0-pulic address, 1-static random address, 2-random resolvable private address */

--- a/component/common/application/matter/common/port/matter_dcts.c
+++ b/component/common/application/matter/common/port/matter_dcts.c
@@ -98,7 +98,7 @@ extern "C" {
 
         // decrypt the encrypted value
         ret = dct_decrypt(encrypted_data, *buffer_size, buffer);
-
+        
         return ret;
     }
 
@@ -107,17 +107,17 @@ extern "C" {
 #endif // MBEDTLS_CIPHER_MODE_CTR
 #endif
 
-int32_t initPref(void)
+s32 initPref(void)
 {
-    int32_t ret;
+    s32 ret;
     ret = dct_init(DCT_BEGIN_ADDR_MATTER, MODULE_NUM, VARIABLE_NAME_SIZE, VARIABLE_VALUE_SIZE, ENABLE_BACKUP, ENABLE_WEAR_LEVELING);
-    if (ret != 0)
+    if (ret != DCT_SUCCESS)
         printf("dct_init failed with error: %d\n", ret);
     else
         printf("dct_init success\n");
 
     ret = dct_init2(DCT_BEGIN_ADDR_MATTER2, MODULE_NUM2, VARIABLE_NAME_SIZE2, VARIABLE_VALUE_SIZE2, ENABLE_BACKUP, ENABLE_WEAR_LEVELING);
-    if (ret != 0)
+    if (ret != DCT_SUCCESS)
         printf("dct_init2 failed with error: %d\n", ret);
     else
         printf("dct_init2 success\n");
@@ -131,17 +131,17 @@ int32_t initPref(void)
     return ret;
 }
 
-int32_t deinitPref(void)
+s32 deinitPref(void)
 {
-    int32_t ret;
+    s32 ret;
     ret = dct_format(DCT_BEGIN_ADDR_MATTER, MODULE_NUM, VARIABLE_NAME_SIZE, VARIABLE_VALUE_SIZE, ENABLE_BACKUP, ENABLE_WEAR_LEVELING);
-    if (ret != 0)
+    if (ret != DCT_SUCCESS)
         printf("dct_format failed with error: %d\n", ret);
     else
         printf("dct_format success\n");
 
     ret = dct_format2(DCT_BEGIN_ADDR_MATTER2, MODULE_NUM2, VARIABLE_NAME_SIZE2, VARIABLE_VALUE_SIZE2, ENABLE_BACKUP, ENABLE_WEAR_LEVELING);
-    if (ret != 0)
+    if (ret != DCT_SUCCESS)
         printf("dct_format2 failed with error: %d\n", ret);
     else
         printf("dct_format2 success\n");
@@ -163,14 +163,14 @@ s32 registerPref()
     {
         snprintf(ns, 15, "matter_kvs1_%d", i+1); 
         ret = dct_register_module(ns);
-        if (ret != 0)
+        if (ret != DCT_SUCCESS)
             goto exit;
         else
             printf("dct_register_module %s success\n", ns);
     }
 
 exit:
-    if (ret != 0)
+    if (ret != DCT_SUCCESS)
         printf("DCT1 modules registration failed");
     return ret;
 }
@@ -184,14 +184,14 @@ s32 registerPref2()
     {
         snprintf(ns, 15, "matter_kvs2_%d", i+1); 
         ret = dct_register_module2(ns);
-        if (ret != 0)
+        if (ret != DCT_SUCCESS)
             goto exit;
         else
             printf("dct_register_module2 %s success\n", ns);
     }
 
 exit:
-    if (ret != 0)
+    if (ret != DCT_SUCCESS)
         printf("DCT2 modules registration failed");
     return ret;
 }
@@ -205,14 +205,14 @@ s32 clearPref()
     {
         snprintf(ns, 15, "matter_kvs1_%d", i+1); 
         ret = dct_unregister_module(ns);
-        if (ret != 0)
+        if (ret != DCT_SUCCESS)
             goto exit;
         else
             printf("dct_unregister_module %s success\n", ns);
     }
 
 exit:
-    if (ret != 0)
+    if (ret != DCT_SUCCESS)
         printf("DCT1 modules unregistration failed");
     return ret;
 }
@@ -226,14 +226,14 @@ s32 clearPref2()
     {
         snprintf(ns, 15, "matter_kvs2_%d", i+1); 
         ret = dct_unregister_module2(ns);
-        if (ret != 0)
+        if (ret != DCT_SUCCESS)
             goto exit;
         else
             printf("dct_unregister_module2 %s success\n", ns);
     }
 
 exit:
-    if (ret != 0)
+    if (ret != DCT_SUCCESS)
         printf("DCT2 modules unregistration failed");
     return ret;
 }
@@ -241,7 +241,7 @@ exit:
 s32 deleteKey(const char *domain, const char *key)
 {
     dct_handle_t handle;
-    s32 ret = -1;
+    s32 ret;
     char ns[15];
 
     // Loop over DCT1 modules
@@ -249,14 +249,14 @@ s32 deleteKey(const char *domain, const char *key)
     {
         snprintf(ns, 15, "matter_kvs1_%d", i+1); 
         ret = dct_open_module(&handle, ns);
-        if (DCT_SUCCESS != ret)
+        if (ret != DCT_SUCCESS)
         {
             printf("%s : dct_open_module(%s) failed with error: %d\n" ,__FUNCTION__, ns, ret);
             goto exit;
         }
         ret = dct_delete_variable(&handle, key);
         dct_close_module(&handle);
-        if (DCT_SUCCESS == ret)
+        if (ret != DCT_SUCCESS)
             return ret;
     }
 
@@ -265,14 +265,14 @@ s32 deleteKey(const char *domain, const char *key)
     {
         snprintf(ns, 15, "matter_kvs2_%d", i+1); 
         ret = dct_open_module2(&handle, ns);
-        if (DCT_SUCCESS != ret)
+        if (ret != DCT_SUCCESS)
         {
             printf("%s : dct_open_module2(%s) failed with error: %d\n" ,__FUNCTION__, ns, ret);
             goto exit;
         }
         ret = dct_delete_variable2(&handle, key);
         dct_close_module2(&handle);
-        if (DCT_SUCCESS == ret)
+        if (ret != DCT_SUCCESS)
             return ret;
     }
 
@@ -283,7 +283,7 @@ exit:
 bool checkExist(const char *domain, const char *key)
 {
     dct_handle_t handle;
-    s32 ret = -1;
+    s32 ret;
     uint16_t len = 0;
     u8 *str = malloc(sizeof(u8) * VARIABLE_VALUE_SIZE2); // use the bigger buffer size
     char ns[15];
@@ -305,8 +305,7 @@ bool checkExist(const char *domain, const char *key)
         {
             printf("checkExist key=%s found.\n", key);
             dct_close_module(&handle);
-            free(str);
-            return true;
+            goto exit;
         }
 
         len = sizeof(u64);
@@ -315,8 +314,7 @@ bool checkExist(const char *domain, const char *key)
         {
             printf("checkExist key=%s found.\n", key);
             dct_close_module(&handle);
-            free(str);
-            return true;
+            goto exit;
         }
 
         dct_close_module(&handle);
@@ -339,8 +337,7 @@ bool checkExist(const char *domain, const char *key)
         {
             printf("checkExist key=%s found.\n", key);
             dct_close_module2(&handle);
-            free(str);
-            return true;
+            goto exit;
         }
 
         dct_close_module2(&handle);
@@ -348,15 +345,14 @@ bool checkExist(const char *domain, const char *key)
 
 exit:
     free(str);
-    return false;
+    return (ret == DCT_SUCCESS) ? true : false;
 }
 
 s32 setPref_new(const char *domain, const char *key, u8 *value, size_t byteCount)
 {
     dct_handle_t handle;
-    s32 ret = -1;
+    s32 ret;
     char ns[15];
-    bool set_success = false;
 
     if (byteCount <= 64)
     {
@@ -378,13 +374,12 @@ s32 setPref_new(const char *domain, const char *key, u8 *value, size_t byteCount
 #else
                 ret = dct_set_variable_new(&handle, key, (char *)value, (uint16_t)byteCount);
 #endif
-                if (DCT_SUCCESS != ret)
+                if (ret != DCT_SUCCESS)
                 {
                     printf("%s : dct_set_variable(%s) failed with error: %d\n" ,__FUNCTION__, key, ret);
                     dct_close_module(&handle);
                     goto exit;
                 }
-                set_success = true;
                 dct_close_module(&handle);
                 break;
             }
@@ -411,13 +406,12 @@ s32 setPref_new(const char *domain, const char *key, u8 *value, size_t byteCount
 #else
                 ret = dct_set_variable_new2(&handle, key, (char *)value, (uint16_t)byteCount);
 #endif
-                if (DCT_SUCCESS != ret)
+                if (ret != DCT_SUCCESS)
                 {
                     printf("%s : dct_set_variable2(%s) failed with error: %d\n" ,__FUNCTION__, key, ret);
                     dct_close_module2(&handle);
                     goto exit;
                 }
-                set_success = true;
                 dct_close_module2(&handle);
                 break;
             }
@@ -426,13 +420,13 @@ s32 setPref_new(const char *domain, const char *key, u8 *value, size_t byteCount
     }
 
 exit:
-    return (set_success == true ? 1 : 0);
+    return ret;
 }
 
 s32 getPref_bool_new(const char *domain, const char *key, u8 *val)
 {
     dct_handle_t handle;
-    s32 ret = -1;
+    s32 ret;
     uint16_t len = sizeof(u8);
     char ns[15];
 
@@ -452,7 +446,7 @@ s32 getPref_bool_new(const char *domain, const char *key, u8 *val)
         ret = dct_get_variable_new(&handle, key, (char *)val, &len);
 #endif
         dct_close_module(&handle);
-        if (DCT_SUCCESS == ret)
+        if (ret == DCT_SUCCESS)
         {
             return ret;
         }
@@ -474,7 +468,7 @@ s32 getPref_bool_new(const char *domain, const char *key, u8 *val)
         ret = dct_get_variable_new2(&handle, key, (char *)val, &len);
 #endif
         dct_close_module2(&handle);
-        if (DCT_SUCCESS == ret)
+        if (ret == DCT_SUCCESS)
         {
             return ret;
         }
@@ -487,7 +481,7 @@ exit:
 s32 getPref_u32_new(const char *domain, const char *key, u32 *val)
 {
     dct_handle_t handle;
-    s32 ret = -1;
+    s32 ret;
     uint16_t len = sizeof(u32);
     char ns[15];
 
@@ -507,7 +501,7 @@ s32 getPref_u32_new(const char *domain, const char *key, u32 *val)
         ret = dct_get_variable_new(&handle, key, (char *)val, &len);
 #endif
         dct_close_module(&handle);
-        if (DCT_SUCCESS == ret)
+        if (ret == DCT_SUCCESS)
         {
             return ret;
         }
@@ -529,7 +523,7 @@ s32 getPref_u32_new(const char *domain, const char *key, u32 *val)
         ret = dct_get_variable_new2(&handle, key, (char *)val, &len);
 #endif
         dct_close_module2(&handle);
-        if (DCT_SUCCESS == ret)
+        if (ret == DCT_SUCCESS)
         {
             return ret;
         }
@@ -542,7 +536,7 @@ exit:
 s32 getPref_u64_new(const char *domain, const char *key, u64 *val)
 {
     dct_handle_t handle;
-    s32 ret = -1;
+    s32 ret;
     uint16_t len = sizeof(u64);
     char ns[15];
 
@@ -562,7 +556,7 @@ s32 getPref_u64_new(const char *domain, const char *key, u64 *val)
         ret = dct_get_variable_new(&handle, key, (char *)val, &len);
 #endif
         dct_close_module(&handle);
-        if (DCT_SUCCESS == ret)
+        if (ret == DCT_SUCCESS)
         {
             return ret;
         }
@@ -584,7 +578,7 @@ s32 getPref_u64_new(const char *domain, const char *key, u64 *val)
         ret = dct_get_variable_new2(&handle, key, (char *)val, &len);
 #endif
         dct_close_module2(&handle);
-        if (DCT_SUCCESS == ret)
+        if (ret == DCT_SUCCESS)
         {
             return ret;
         }
@@ -597,7 +591,7 @@ exit:
 s32 getPref_str_new(const char *domain, const char *key, char * buf, size_t bufSize, size_t *outLen)
 {
     dct_handle_t handle;
-    s32 ret = -1;
+    s32 ret;
     char ns[15];
 
     // Loop over DCT1 modules
@@ -616,7 +610,7 @@ s32 getPref_str_new(const char *domain, const char *key, char * buf, size_t bufS
         ret = dct_get_variable_new(&handle, key, buf, &bufSize);
 #endif
         dct_close_module(&handle);
-        if (DCT_SUCCESS == ret)
+        if (ret == DCT_SUCCESS)
         {
             *outLen = bufSize;
             return ret;
@@ -639,7 +633,7 @@ s32 getPref_str_new(const char *domain, const char *key, char * buf, size_t bufS
         ret = dct_get_variable_new2(&handle, key, buf, &bufSize);
 #endif
         dct_close_module2(&handle);
-        if (DCT_SUCCESS == ret)
+        if (ret == DCT_SUCCESS)
         {
             *outLen = bufSize;
             return ret;
@@ -653,7 +647,7 @@ exit:
 s32 getPref_bin_new(const char *domain, const char *key, u8 * buf, size_t bufSize, size_t *outLen)
 {
     dct_handle_t handle;
-    s32 ret = -1;
+    s32 ret;
     char ns[15];
 
     // Loop over DCT1 modules
@@ -672,7 +666,7 @@ s32 getPref_bin_new(const char *domain, const char *key, u8 * buf, size_t bufSiz
         ret = dct_get_variable_new(&handle, key, (char *)buf, &bufSize);
 #endif
         dct_close_module(&handle);
-        if (DCT_SUCCESS == ret)
+        if (ret == DCT_SUCCESS)
         {
             *outLen = bufSize;
             return ret;
@@ -695,7 +689,7 @@ s32 getPref_bin_new(const char *domain, const char *key, u8 * buf, size_t bufSiz
         ret = dct_get_variable_new2(&handle, key, (char *)buf, &bufSize);
 #endif
         dct_close_module2(&handle);
-        if (DCT_SUCCESS == ret)
+        if (ret == DCT_SUCCESS)
         {
             *outLen = bufSize;
             return ret;

--- a/component/common/application/matter/common/port/matter_timers.c
+++ b/component/common/application/matter/common/port/matter_timers.c
@@ -5,7 +5,7 @@
 #include "platform/platform_stdlib.h"
 
 #ifdef __cplusplus
-extern "C" {
+ extern "C" {
 #endif
 
 #include "stddef.h"
@@ -13,6 +13,7 @@ extern "C" {
 #include "errno.h"
 #include "FreeRTOS.h"
 #include "chip_porting.h"
+#include "rtc_api.h"
 
 #define MICROSECONDS_PER_SECOND    ( 1000000LL )                                   /**< Microseconds per second. */
 #define NANOSECONDS_PER_SECOND     ( 1000000000LL )                                /**< Nanoseconds per second. */
@@ -20,6 +21,23 @@ extern "C" {
 
 int FreeRTOS_errno = 0;
 #define errno FreeRTOS_errno
+
+BOOL UTILS_ValidateTimespec( const struct timespec * const pxTimespec )
+{
+    BOOL xReturn = FALSE;
+
+    if( pxTimespec != NULL )
+    {
+        /* Verify 0 <= tv_nsec < 1000000000. */
+        if( ( pxTimespec->tv_nsec >= 0 ) &&
+            ( pxTimespec->tv_nsec < NANOSECONDS_PER_SECOND ) )
+        {
+            xReturn = TRUE;
+        }
+    }
+
+    return xReturn;
+}
 
 bool UTILS_ValidateTimespec( const struct timespec * const pxTimespec );
 
@@ -79,23 +97,6 @@ int UTILS_TimespecToTicks( const struct timespec * const pxTimespec, TickType_t 
     }
 
     return iStatus;
-}
-
-bool UTILS_ValidateTimespec( const struct timespec * const pxTimespec )
-{
-    bool xReturn = FALSE;
-
-    if( pxTimespec != NULL )
-    {
-        /* Verify 0 <= tv_nsec < 1000000000. */
-        if( ( pxTimespec->tv_nsec >= 0 ) &&
-            ( pxTimespec->tv_nsec < NANOSECONDS_PER_SECOND ) )
-        {
-            xReturn = TRUE;
-        }
-    }
-
-    return xReturn;
 }
 
 int _nanosleep( const struct timespec * rqtp,
@@ -179,6 +180,21 @@ int _vTaskDelay( const TickType_t xTicksToDelay )
     vTaskDelay(xTicksToDelay);
 
     return 0;
+}
+
+void matter_rtc_init()
+{
+    rtc_init();
+}
+
+long long matter_rtc_read()
+{
+    return rtc_read();
+}
+
+void matter_rtc_write(long long time)
+{
+    rtc_write(time);
 }
 
 #ifdef __cplusplus

--- a/component/common/application/matter/common/port/matter_timers.h
+++ b/component/common/application/matter/common/port/matter_timers.h
@@ -10,11 +10,15 @@ extern "C" {
 #endif
 
 #include <wifi_conf.h>
+#include <time.h>
 
 typedef u32 TickType_t;
 int _nanosleep( const struct timespec * rqtp, struct timespec * rmtp );
 int _vTaskDelay( const TickType_t xTicksToDelay );
 time_t _time( time_t * tloc );
+void matter_rtc_init(void);
+long long matter_rtc_read(void);
+void matter_rtc_write(long long time);
 
 #ifdef __cplusplus
 }

--- a/component/common/application/matter/common/port/matter_utils.c
+++ b/component/common/application/matter/common/port/matter_utils.c
@@ -268,7 +268,7 @@ int32_t ReadFactory(uint8_t *buffer, uint16_t *pfactorydata_len)
 
 int32_t DecodeFactory(uint8_t *buffer, FactoryData *fdp, uint16_t data_len)
 {
-    int32_t ret = 0;
+    int32_t ret = 1;
     pb_istream_t stream;
     FactoryDataProvider FDP = FactoryDataProvider_init_zero;
 

--- a/component/common/application/matter/common/port/matter_wifis.c
+++ b/component/common/application/matter/common/port/matter_wifis.c
@@ -5,15 +5,15 @@
 #include "platform/platform_stdlib.h"
 
 #ifdef __cplusplus
-extern "C" {
+ extern "C" {
 #endif
 
 #include "stddef.h"
 #include "string.h"
 #include "wifi_conf.h"
 #include "chip_porting.h"
-  
-uint32_t apNum = 0; // no of total AP scanned
+
+u32 apNum = 0; // no of total AP scanned
 static rtw_scan_result_t matter_userdata[65] = {0};
 static char *matter_ssid;
 
@@ -73,7 +73,7 @@ static rtw_result_t matter_scan_result_handler( rtw_scan_handler_result_t* mallo
             if(malloced_scan_result->user_data)
                 memcpy((void *)((char *)malloced_scan_result->user_data+(apNum-1)*sizeof(rtw_scan_result_t)), (char *)record, sizeof(rtw_scan_result_t));
         }
-    } 
+    }
     else
     {
         if (chip_connmgr_callback_func && chip_connmgr_callback_data)
@@ -104,7 +104,7 @@ static rtw_result_t matter_scan_with_ssid_result_handler( rtw_scan_handler_resul
             memcpy((void *)((char *)malloced_scan_result->user_data+(apNum-1)*sizeof(rtw_scan_result_t)), (char *)record, sizeof(rtw_scan_result_t));
             print_matter_scan_result(record);
         }
-    } 
+    }
     else
     {
         if (chip_connmgr_callback_func && chip_connmgr_callback_data)
@@ -212,13 +212,13 @@ static int matter_get_ap_security_mode(IN char * ssid, OUT rtw_security_t *secur
 }
 
 int matter_wifi_connect(
-    char                 *ssid,
+    char              *ssid,
     rtw_security_t    security_type,
-    char                 *password,
-    int                 ssid_len,
-    int                 password_len,
-    int                 key_id,
-    void                 *semaphore)
+    char              *password,
+    int               ssid_len,
+    int               password_len,
+    int               key_id,
+    void              *semaphore)
 {
     u8 connect_channel;
     int security_retry_count = 0;
@@ -280,16 +280,62 @@ int matter_wifi_is_connected_to_ap(void)
     return wifi_is_connected_to_ap();
 }
 
-uint8_t matter_lwip_dhcp(uint8_t idx, uint8_t dhcp_state)
+void matter_lwip_dhcp()
 {
-    if (dhcp_state == DHCP_START)
+    LwIP_DHCP(0, DHCP_START);
+}
+
+void matter_lwip_dhcp6(void)
+{
+    LwIP_DHCP6(0, DHCP6_START);
+}
+
+void matter_lwip_releaseip(void)
+{
+    LwIP_ReleaseIP(0);
+}
+
+int matter_wifi_get_ap_bssid(unsigned char *bssid)
+{
+    return wifi_get_ap_bssid(bssid);
+}
+
+int matter_wifi_get_network_mode(rtw_network_mode_t *pmode)
+{
+    return wifi_get_network_mode(pmode);
+}
+
+int matter_wifi_get_security_type(const char *ifname, uint16_t *alg, uint8_t *key_idx, uint8_t *passphrase)
+{
+    if (wext_get_enc_ext(ifname, alg, key_idx, passphrase) < 0)
     {
-        LwIP_DHCP(0, DHCP_START);
+        return RTW_ERROR;
     }
-    else if (dhcp_state == DHCP6_START)
+    return RTW_SUCCESS;
+}
+
+int matter_wifi_get_wifi_channel_number(const char *ifname, uint8_t *ch)
+{
+    if (wext_get_channel(ifname, ch) < 0)
     {
-        LwIP_DHCP6(0, DHCP6_START);
+        return RTW_ERROR;
     }
+    return RTW_SUCCESS;
+}
+
+int matter_wifi_get_rssi(int *prssi)
+{
+    return wifi_get_rssi(prssi);
+}
+
+int matter_wifi_get_mac_address(char *mac)
+{
+    return wifi_get_mac_address(mac);
+}
+
+int matter_wifi_get_last_error()
+{
+    return wifi_get_last_error();
 }
 
 #ifdef __cplusplus

--- a/component/common/application/matter/common/port/matter_wifis.h
+++ b/component/common/application/matter/common/port/matter_wifis.h
@@ -25,7 +25,7 @@ typedef int (*chip_connmgr_callback)(void *object);
 void chip_connmgr_set_callback_func(chip_connmgr_callback p, void *data);
 void matter_scan_networks(void);
 void matter_scan_networks_with_ssid(const unsigned char *ssid, size_t length);
-rtw_scan_result_t *matter_get_scan_results();
+rtw_scan_result_t *matter_get_scan_results(void);
 int matter_wifi_connect(
     char              *ssid,
     rtw_security_t    security_type,
@@ -39,7 +39,17 @@ int matter_wifi_disconnect(void);
 int matter_wifi_on(rtw_mode_t mode);
 int matter_wifi_set_mode(rtw_mode_t mode);
 int matter_wifi_is_connected_to_ap(void);
-uint8_t matter_lwip_dhcp(uint8_t idx, uint8_t dhcp_state);
+void matter_lwip_dhcp(void);
+void matter_lwip_dhcp6(void);
+void matter_lwip_releaseip(void);
+int matter_wifi_get_ap_bssid(unsigned char*);
+int matter_wifi_get_network_mode(rtw_network_mode_t *pmode);
+int matter_wifi_get_security_type(const char *ifname, uint16_t *alg, uint8_t *key_idx, uint8_t *passphrase);
+int matter_wifi_get_wifi_channel_number(const char *ifname, uint8_t *ch);
+int matter_wifi_get_rssi(int *prssi);
+int matter_wifi_get_mac_address(char *mac);
+int matter_wifi_get_last_error(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/all_clusters_app/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/all_clusters_app/Makefile
@@ -86,6 +86,8 @@ IFLAGS += -I$(CODEGEN_DIR)
 #                               Source FILE LIST                              #
 #*****************************************************************************#
 
+CPPSRC += $(CHIPDIR)/src/app/server/AclStorage.cpp
+CPPSRC += $(CHIPDIR)/src/app/server/DefaultAclStorage.cpp
 CPPSRC += $(CHIPDIR)/src/app/server/Server.cpp
 CPPSRC += $(CHIPDIR)/src/app/server/Dnssd.cpp
 CPPSRC += $(CHIPDIR)/src/app/server/EchoHandler.cpp

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/bridge_port/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/bridge_port/Makefile
@@ -93,6 +93,8 @@ IFLAGS += -I$(CODEGEN_DIR)
 #                               Source FILE LIST                              #
 #*****************************************************************************#
 
+CPPSRC += $(CHIPDIR)/src/app/server/AclStorage.cpp
+CPPSRC += $(CHIPDIR)/src/app/server/DefaultAclStorage.cpp
 CPPSRC += $(CHIPDIR)/src/app/server/Server.cpp
 CPPSRC += $(CHIPDIR)/src/app/server/Dnssd.cpp
 CPPSRC += $(CHIPDIR)/src/app/server/EchoHandler.cpp

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/lighting_app/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/lighting_app/Makefile
@@ -85,6 +85,8 @@ IFLAGS += -I$(CODEGEN_DIR)
 #                               Source FILE LIST                              #
 #*****************************************************************************#
 
+CPPSRC += $(CHIPDIR)/src/app/server/AclStorage.cpp
+CPPSRC += $(CHIPDIR)/src/app/server/DefaultAclStorage.cpp
 CPPSRC += $(CHIPDIR)/src/app/server/Server.cpp
 CPPSRC += $(CHIPDIR)/src/app/server/Dnssd.cpp
 CPPSRC += $(CHIPDIR)/src/app/server/EchoHandler.cpp

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/lighting_port/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/lighting_port/Makefile
@@ -95,6 +95,8 @@ IFLAGS += -I$(CODEGEN_DIR)
 #                               Source FILE LIST                              #
 #*****************************************************************************#
 
+CPPSRC += $(CHIPDIR)/src/app/server/AclStorage.cpp
+CPPSRC += $(CHIPDIR)/src/app/server/DefaultAclStorage.cpp
 CPPSRC += $(CHIPDIR)/src/app/server/Server.cpp
 CPPSRC += $(CHIPDIR)/src/app/server/Dnssd.cpp
 CPPSRC += $(CHIPDIR)/src/app/server/EchoHandler.cpp

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/thermostat_port/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/thermostat_port/Makefile
@@ -95,6 +95,8 @@ IFLAGS += -I$(CODEGEN_DIR)
 #                               Source FILE LIST                              #
 #*****************************************************************************#
 
+CPPSRC += $(CHIPDIR)/src/app/server/AclStorage.cpp
+CPPSRC += $(CHIPDIR)/src/app/server/DefaultAclStorage.cpp
 CPPSRC += $(CHIPDIR)/src/app/server/Server.cpp
 CPPSRC += $(CHIPDIR)/src/app/server/Dnssd.cpp
 CPPSRC += $(CHIPDIR)/src/app/server/EchoHandler.cpp


### PR DESCRIPTION
### Error mapping
- Standardize return types for below api
  - wifi
  - dct
  - flash
- The real mapping happens inside AmebaUtils in matter sdk
- Added timer related api
- Added more wifi related api

### DHCP split into ipv4 and ipv6
- run dhcp for both ipv4 and ipv6
- matter will call release ip api on disconnect

### Build
- add AclStorage and DefaultAclStorage

