### PR TITLE
[build] Add logging option

### DIFF
--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip/all_clusters_app/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip/all_clusters_app/Makefile
@@ -58,6 +58,10 @@ GENERATE_NINJA:
 	echo chip_build_libshell = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_detail_logging = "false" >> $(OUTPUT_DIR)/args.gn && \
 	cd $(CHIPDIR) && PW_ENVSETUP_QUIET=1 . scripts/activate.sh && \
 	mkdir -p $(CHIPDIR)/config/ameba/components/chip && \
 	cd $(CHIPDIR)/config/ameba/components/chip && gn gen --check --fail-on-unused-args $(CHIPDIR)/examples/all-clusters-app/ameba/build/chip && \

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip/bridge_app/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip/bridge_app/Makefile
@@ -57,6 +57,10 @@ GENERATE_NINJA:
 	echo chip_enable_ota_requestor = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_detail_logging = "false" >> $(OUTPUT_DIR)/args.gn && \
 	cd $(CHIPDIR) && PW_ENVSETUP_QUIET=1 . scripts/activate.sh && \
 	mkdir -p $(CHIPDIR)/config/ameba/components/chip && \
 	cd $(CHIPDIR)/config/ameba/components/chip && gn gen --check --fail-on-unused-args $(CHIPDIR)/examples/bridge-app/ameba/build/chip && \

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip/lighting_app/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip/lighting_app/Makefile
@@ -57,6 +57,10 @@ GENERATE_NINJA:
 	echo chip_enable_ota_requestor = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_detail_logging = "false" >> $(OUTPUT_DIR)/args.gn && \
 	cd $(CHIPDIR) && PW_ENVSETUP_QUIET=1 . scripts/activate.sh && \
 	mkdir -p $(CHIPDIR)/config/ameba/components/chip && \
 	cd $(CHIPDIR)/config/ameba/components/chip && gn gen --check --fail-on-unused-args $(CHIPDIR)/examples/lighting-app/ameba/build/chip && \

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip/thermostat_app/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip/thermostat_app/Makefile
@@ -57,6 +57,10 @@ GENERATE_NINJA:
 	echo chip_enable_ota_requestor = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_error_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_progress_logging  = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_detail_logging = "false" >> $(OUTPUT_DIR)/args.gn && \
 	cd $(CHIPDIR) && PW_ENVSETUP_QUIET=1 . scripts/activate.sh && \
 	mkdir -p $(CHIPDIR)/config/ameba/components/chip && \
 	cd $(CHIPDIR)/config/ameba/components/chip && gn gen --check --fail-on-unused-args $(CHIPDIR)/examples/thermostat/ameba/build/chip && \


### PR DESCRIPTION
- Add chip_logging option into makefile. This allows user to enable or disable matter logging.
- On default disable chip_detail_logging