### PR TITLE
[wifi] Updated wifi_conf.c and matter_wifis.c for issue #75 and #77

### DIFF
--- a/component/common/api/wifi/wifi_conf.c
+++ b/component/common/api/wifi/wifi_conf.c
@@ -3749,7 +3749,9 @@ int wifi_get_sta_security_type(void)
 	if(join_user_data != NULL)
 	{
 		return join_user_data->network_info.security_type;
-	} else {
+	} 
+	else 
+	{
 		return -1;
 	}
 }

--- a/component/common/api/wifi/wifi_conf.c
+++ b/component/common/api/wifi/wifi_conf.c
@@ -3749,6 +3749,8 @@ int wifi_get_sta_security_type(void)
 	if(join_user_data != NULL)
 	{
 		return join_user_data->network_info.security_type;
+	} else {
+		return -1;
 	}
 }
 

--- a/component/common/application/matter/common/port/matter_wifis.c
+++ b/component/common/application/matter/common/port/matter_wifis.c
@@ -338,7 +338,9 @@ int matter_wifi_connect(
 
     matter_wifi_trigger = 1;
     matter_set_autoreconnect(1);
-    return wifi_connect(ssid, security_type, password, strlen(ssid), strlen(password), key_id, NULL);
+    wifi_connect(ssid, security_type, password, strlen(ssid), strlen(password), key_id, NULL);
+
+    return RTW_SUCCESS;
 }
 
 int matter_get_sta_wifi_info(rtw_wifi_setting_t *pSetting)

--- a/component/common/application/matter/common/port/matter_wifis.c
+++ b/component/common/application/matter/common/port/matter_wifis.c
@@ -338,9 +338,7 @@ int matter_wifi_connect(
 
     matter_wifi_trigger = 1;
     matter_set_autoreconnect(1);
-    wifi_connect(ssid, security_type, password, strlen(ssid), strlen(password), key_id, NULL);
-
-    return RTW_SUCCESS;
+    return wifi_connect(ssid, security_type, password, strlen(ssid), strlen(password), key_id, NULL);
 }
 
 int matter_get_sta_wifi_info(rtw_wifi_setting_t *pSetting)


### PR DESCRIPTION
- [Issue #75](https://github.com/ambiot/ambd_matter/issues/75): Updated wifi_conf.c, wifi_get_sta_security_type, return -1 when join_user_data is NULL.
- [Issue #77](https://github.com/ambiot/ambd_matter/issues/77): Updated matter_wifis.c, matter_wifi_connect, removed err variable and directly return wifi_connect result.