### PR TITLE
[ble-wifi] Factory Reset Fix

### DIFF
--- a/component/common/application/matter/common/atcmd/atcmd_matter.c
+++ b/component/common/application/matter/common/atcmd/atcmd_matter.c
@@ -32,7 +32,9 @@ void fATchipapp(void *arg)
 	printf("Erased Fast Connect data\r\n");
 #endif
 
-	AT_PRINTK("[ATS#]: _AT_SYSTEM_TEST_");
+	AT_PRINTK("[ATM$]: _AT_SYSTEM_TEST_");
+	wifi_disconnect();
+	sys_reset();
 }
 
 void fATchipapp1(void *arg)


### PR DESCRIPTION
- edited atcmd_matter.c to disconnect the current WiFi and reset the board in the factory reset function