### PR TITLE
[portinglayer] Fix include header

### DIFF
--- a/component/common/application/matter/core/matter_core.cpp
+++ b/component/common/application/matter/core/matter_core.cpp
@@ -33,7 +33,7 @@
 
 #include <support/CHIPMem.h>
 #include <support/CodeUtils.h>
-#include <support/ErrorStr.h>
+#include <core/ErrorStr.h>
 
 #if CONFIG_ENABLE_CHIP_SHELL
 #include <shell/launch_shell.h>


### PR DESCRIPTION
changed '#include <support/ErrorStr.h>' to '#include <core/ErrorStr.h>' because the file in the connectedhomeip repository was moved