### PR TITLE
[build] Fix disable OTA Requestor

### DIFF
--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/all_clusters_app/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/all_clusters_app/Makefile
@@ -29,6 +29,8 @@ include $(MAKE_INCLUDE_GEN)
 OUTPUT_DIR = $(CHIPDIR)/examples/all-clusters-app/ameba/build/chip
 CODEGEN_DIR = $(OUTPUT_DIR)/codegen
 
+CHIP_ENABLE_OTA_REQUESTOR = $(shell grep 'chip_enable_ota_requestor' $(OUTPUT_DIR)/args.gn | cut -d' ' -f3)
+
 DIR = $(SRCDIR)
 DIR += $(CHIPDIR)/src/app
 DIR += $(CHIPDIR)/src/app/server
@@ -141,7 +143,9 @@ CPPSRC += $(CHIPDIR)/examples/all-clusters-app/ameba/main/CHIPDeviceManager.cpp
 CPPSRC += $(CHIPDIR)/examples/all-clusters-app/ameba/main/Globals.cpp
 CPPSRC += $(CHIPDIR)/examples/all-clusters-app/ameba/main/LEDWidget.cpp
 
+ifeq ($(CHIP_ENABLE_OTA_REQUESTOR), true)
 CPPSRC += $(CHIPDIR)/examples/platform/ameba/ota/OTAInitializer.cpp
+endif
 CPPSRC += $(CHIPDIR)/examples/platform/ameba/shell/launch_shell.cpp
 CPPSRC += $(CHIPDIR)/examples/platform/ameba/test_event_trigger/AmebaTestEventTriggerDelegate.cpp
 CPPSRC += $(CHIPDIR)/examples/providers/DeviceInfoProviderImpl.cpp

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/lighting_app/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/lighting_app/Makefile
@@ -29,6 +29,8 @@ include $(MAKE_INCLUDE_GEN)
 OUTPUT_DIR = $(CHIPDIR)/examples/lighting-app/ameba/build/chip
 CODEGEN_DIR = $(OUTPUT_DIR)/codegen
 
+CHIP_ENABLE_OTA_REQUESTOR = $(shell grep 'chip_enable_ota_requestor' $(OUTPUT_DIR)/args.gn | cut -d' ' -f3)
+
 DIR = $(SRCDIR)
 DIR += $(CHIPDIR)/src/app
 DIR += $(CHIPDIR)/src/app/server
@@ -123,7 +125,9 @@ CPPSRC += $(CHIPDIR)/examples/lighting-app/ameba/main/CHIPDeviceManager.cpp
 CPPSRC += $(CHIPDIR)/examples/lighting-app/ameba/main/Globals.cpp
 CPPSRC += $(CHIPDIR)/examples/lighting-app/ameba/main/LEDWidget.cpp
 
+ifeq ($(CHIP_ENABLE_OTA_REQUESTOR), true)
 CPPSRC += $(CHIPDIR)/examples/platform/ameba/ota/OTAInitializer.cpp
+endif
 CPPSRC += $(CHIPDIR)/examples/providers/DeviceInfoProviderImpl.cpp
 
 CPPSRC += $(BASEDIR)/component/common/application/matter/api/matter_api.cpp

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/lighting_dm_app/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/lighting_dm_app/Makefile
@@ -29,6 +29,8 @@ include $(MAKE_INCLUDE_GEN)
 OUTPUT_DIR = $(CHIPDIR)/examples/lighting-app/ameba/build/chip
 CODEGEN_DIR = $(OUTPUT_DIR)/codegen
 
+CHIP_ENABLE_OTA_REQUESTOR = $(shell grep 'chip_enable_ota_requestor' $(OUTPUT_DIR)/args.gn | cut -d' ' -f3)
+
 DIR = $(SRCDIR)
 DIR += $(CHIPDIR)/src/app
 DIR += $(CHIPDIR)/src/app/server
@@ -138,7 +140,9 @@ CPPSRC += $(BASEDIR)/component/common/application/matter/core/matter_core.cpp
 CPPSRC += $(BASEDIR)/component/common/application/matter/core/matter_data_model.cpp
 CPPSRC += $(BASEDIR)/component/common/application/matter/core/matter_data_model_presets.cpp
 CPPSRC += $(BASEDIR)/component/common/application/matter/core/matter_interaction.cpp
+ifeq ($(CHIP_ENABLE_OTA_REQUESTOR), true)
 CPPSRC += $(BASEDIR)/component/common/application/matter/core/matter_ota_initializer.cpp
+endif
 CPPSRC += $(BASEDIR)/component/common/application/matter/driver/led_driver.cpp
 CPPSRC += $(BASEDIR)/component/common/application/matter/example/light_dm/example_matter_light.cpp
 CPPSRC += $(BASEDIR)/component/common/application/matter/example/light_dm/matter_drivers.cpp

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/lighting_port/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/lighting_port/Makefile
@@ -29,6 +29,8 @@ include $(MAKE_INCLUDE_GEN)
 OUTPUT_DIR = $(CHIPDIR)/examples/lighting-app/ameba/build/chip
 CODEGEN_DIR = $(OUTPUT_DIR)/codegen
 
+CHIP_ENABLE_OTA_REQUESTOR = $(shell grep 'chip_enable_ota_requestor' $(OUTPUT_DIR)/args.gn | cut -d' ' -f3)
+
 DIR = $(SRCDIR)
 DIR += $(CHIPDIR)/src/app
 DIR += $(CHIPDIR)/src/app/server
@@ -136,7 +138,9 @@ CSRC += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_table.c
 CPPSRC += $(BASEDIR)/component/common/application/matter/api/matter_api.cpp
 CPPSRC += $(BASEDIR)/component/common/application/matter/core/matter_core.cpp
 CPPSRC += $(BASEDIR)/component/common/application/matter/core/matter_interaction.cpp
+ifeq ($(CHIP_ENABLE_OTA_REQUESTOR), true)
 CPPSRC += $(BASEDIR)/component/common/application/matter/core/matter_ota_initializer.cpp
+endif
 CPPSRC += $(BASEDIR)/component/common/application/matter/driver/led_driver.cpp
 CPPSRC += $(BASEDIR)/component/common/application/matter/example/light/example_matter_light.cpp
 CPPSRC += $(BASEDIR)/component/common/application/matter/example/light/matter_drivers.cpp

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/refrigerator_port/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/refrigerator_port/Makefile
@@ -29,6 +29,8 @@ include $(MAKE_INCLUDE_GEN)
 OUTPUT_DIR = $(CHIPDIR)/examples/refrigerator-app/ameba/build/chip
 CODEGEN_DIR = $(OUTPUT_DIR)/codegen
 
+CHIP_ENABLE_OTA_REQUESTOR = $(shell grep 'chip_enable_ota_requestor' $(OUTPUT_DIR)/args.gn | cut -d' ' -f3)
+
 DIR = $(SRCDIR)
 DIR += $(CHIPDIR)/src/app
 DIR += $(CHIPDIR)/src/app/server
@@ -136,7 +138,9 @@ CSRC += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_table.c
 CPPSRC += $(BASEDIR)/component/common/application/matter/api/matter_api.cpp
 CPPSRC += $(BASEDIR)/component/common/application/matter/core/matter_core.cpp
 CPPSRC += $(BASEDIR)/component/common/application/matter/core/matter_interaction.cpp
+ifeq ($(CHIP_ENABLE_OTA_REQUESTOR), true)
 CPPSRC += $(BASEDIR)/component/common/application/matter/core/matter_ota_initializer.cpp
+endif
 CPPSRC += $(BASEDIR)/component/common/application/matter/driver/tcc_mode.cpp
 CPPSRC += $(BASEDIR)/component/common/application/matter/driver/refrigerator_driver.cpp
 CPPSRC += $(BASEDIR)/component/common/application/matter/example/refrigerator/example_matter_refrigerator.cpp

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/thermostat_port/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/thermostat_port/Makefile
@@ -29,6 +29,8 @@ include $(MAKE_INCLUDE_GEN)
 OUTPUT_DIR = $(CHIPDIR)/examples/thermostat/ameba/build/chip
 CODEGEN_DIR = $(OUTPUT_DIR)/codegen
 
+CHIP_ENABLE_OTA_REQUESTOR = $(shell grep 'chip_enable_ota_requestor' $(OUTPUT_DIR)/args.gn | cut -d' ' -f3)
+
 DIR = $(SRCDIR)
 DIR += $(CHIPDIR)/src/app
 DIR += $(CHIPDIR)/src/app/server
@@ -136,7 +138,9 @@ CSRC += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_table.c
 CPPSRC += $(BASEDIR)/component/common/application/matter/api/matter_api.cpp
 CPPSRC += $(BASEDIR)/component/common/application/matter/core/matter_core.cpp
 CPPSRC += $(BASEDIR)/component/common/application/matter/core/matter_interaction.cpp
+ifeq ($(CHIP_ENABLE_OTA_REQUESTOR), true)
 CPPSRC += $(BASEDIR)/component/common/application/matter/core/matter_ota_initializer.cpp
+endif
 CPPSRC += $(BASEDIR)/component/common/application/matter/driver/thermostat.cpp
 CPPSRC += $(BASEDIR)/component/common/application/matter/driver/thermostat_ui.cpp
 CPPSRC += $(BASEDIR)/component/common/application/matter/example/thermostat/example_matter_thermostat.cpp


### PR DESCRIPTION
- Exclude Ameba Matter OTA Initializer cpp file when chip_enable_ota_requestor is set to false