### PR TITLE
[wifi] Matter API update

### DIFF
--- a/component/common/application/matter/common/port/chip_porting.h
+++ b/component/common/application/matter/common/port/chip_porting.h
@@ -19,6 +19,7 @@ extern "C" {
 #include <stdarg.h>
 #include <platform_opts_bt.h>
 #include <dct.h>
+#include <wifi_structures.h>
 
 #if CONFIG_BT_MATTER_ADAPTER
 /** @brief  Config local address type: 0-pulic address, 1-static random address, 2-random resolvable private address */

--- a/component/common/application/matter/common/port/matter_wifis.c
+++ b/component/common/application/matter/common/port/matter_wifis.c
@@ -458,6 +458,8 @@ void matter_set_autoreconnect(u8 mode)
     wifi_set_autoreconnect(mode);
 }
 
+#if LWIP_VERSION_MAJOR > 2 || LWIP_VERSION_MINOR > 0
+#if LWIP_IPV6
 uint8_t *matter_LwIP_GetIPv6_linklocal(uint8_t idx)
 {
     return LwIP_GetIPv6_linklocal(&xnetif[idx]);
@@ -467,6 +469,8 @@ uint8_t *matter_LwIP_GetIPv6_global(uint8_t idx)
 {
     return LwIP_GetIPv6_global(&xnetif[idx]);
 }
+#endif // LWIP_IPV6
+#endif // LWIP_VERSION_MAJOR > 2 || LWIP_VERSION_MINOR > 0
 
 unsigned char *matter_LwIP_GetIP(uint8_t idx)
 {

--- a/component/common/application/matter/common/port/matter_wifis.c
+++ b/component/common/application/matter/common/port/matter_wifis.c
@@ -34,6 +34,14 @@ extern char wps_profile_ssid[33];
 extern char wps_profile_password[65];
 #endif
 
+unsigned int wifi_event[] =
+{
+    WIFI_EVENT_CONNECT,
+    WIFI_EVENT_FOURWAY_HANDSHAKE_DONE,
+    WIFI_EVENT_DISCONNECT,
+    WIFI_EVENT_DHCP6_DONE
+};
+
 chip_connmgr_callback chip_connmgr_callback_func = NULL;
 void *chip_connmgr_callback_data = NULL;
 void chip_connmgr_set_callback_func(chip_connmgr_callback p, void *data)
@@ -420,20 +428,50 @@ int matter_wifi_get_network_mode(rtw_network_mode_t *pmode)
     return wifi_get_network_mode(pmode);
 }
 
-int matter_wifi_get_security_type(const char *ifname, uint16_t *alg, uint8_t *key_idx, uint8_t *passphrase)
+int matter_wifi_get_security_type(uint8_t wlan_idx, uint16_t *alg, uint8_t *key_idx, uint8_t *passphrase)
 {
-    if (wext_get_enc_ext(ifname, alg, key_idx, passphrase) < 0)
+    switch(wlan_idx)
     {
-        return RTW_ERROR;
+        case(WLAN0_IDX):
+        {
+            if (wext_get_enc_ext(WLAN0_NAME, alg, key_idx, passphrase) < 0)
+            {
+                return RTW_ERROR;
+            }
+            break;
+        }
+        case(WLAN1_IDX):
+        {
+            if (wext_get_enc_ext(WLAN1_NAME, alg, key_idx, passphrase) < 0)
+            {
+                return RTW_ERROR;
+            }
+            break;
+        }
     }
     return RTW_SUCCESS;
 }
 
-int matter_wifi_get_wifi_channel_number(const char *ifname, uint8_t *ch)
+int matter_wifi_get_wifi_channel_number(uint8_t wlan_idx, uint8_t *ch)
 {
-    if (wext_get_channel(ifname, ch) < 0)
+    switch(wlan_idx)
     {
-        return RTW_ERROR;
+        case(WLAN0_IDX):
+        {
+            if (wext_get_channel(WLAN0_NAME, ch) < 0)
+            {
+                return RTW_ERROR;
+            }
+            break;
+        }
+        case(WLAN1_IDX):
+        {
+            if (wext_get_channel(WLAN1_NAME, ch) < 0)
+            {
+                return RTW_ERROR;
+            }
+            break;
+        }
     }
     return RTW_SUCCESS;
 }
@@ -497,6 +535,11 @@ int matter_wifi_get_setting(unsigned char wlan_idx, rtw_wifi_setting_t *psetting
     {
     return wifi_get_setting(WLAN1_NAME, psetting);
     }
+}
+
+void matter_wifi_reg_event_handler(matter_wifi_event event_cmds, rtw_event_handler_t handler_func, void *handler_user_data)
+{
+    wifi_reg_event_handler(wifi_event[event_cmds], handler_func, handler_user_data);
 }
 
 #ifdef __cplusplus

--- a/component/common/application/matter/common/port/matter_wifis.c
+++ b/component/common/application/matter/common/port/matter_wifis.c
@@ -529,11 +529,11 @@ int matter_wifi_get_setting(unsigned char wlan_idx, rtw_wifi_setting_t *psetting
 {
     if (wlan_idx == WLAN0_IDX)
     {
-    return wifi_get_setting(WLAN0_NAME, psetting);
+        return wifi_get_setting(WLAN0_NAME, psetting);
     }
     else
     {
-    return wifi_get_setting(WLAN1_NAME, psetting);
+        return wifi_get_setting(WLAN1_NAME, psetting);
     }
 }
 

--- a/component/common/application/matter/common/port/matter_wifis.c
+++ b/component/common/application/matter/common/port/matter_wifis.c
@@ -458,6 +458,43 @@ void matter_set_autoreconnect(u8 mode)
     wifi_set_autoreconnect(mode);
 }
 
+uint8_t *matter_LwIP_GetIPv6_linklocal(uint8_t idx)
+{
+    return LwIP_GetIPv6_linklocal(&xnetif[idx]);
+}
+
+uint8_t *matter_LwIP_GetIPv6_global(uint8_t idx)
+{
+    return LwIP_GetIPv6_global(&xnetif[idx]);
+}
+
+unsigned char *matter_LwIP_GetIP(uint8_t idx)
+{
+    return LwIP_GetIP(&xnetif[idx]);
+}
+
+unsigned char *matter_LwIP_GetGW(uint8_t idx)
+{
+    return LwIP_GetGW(&xnetif[idx]);
+}
+
+uint8_t *matter_LwIP_GetMASK(uint8_t idx)
+{
+    return LwIP_GetMASK(&xnetif[idx]);
+}
+
+int matter_wifi_get_setting(unsigned char wlan_idx, rtw_wifi_setting_t *psetting)
+{
+    if (wlan_idx == WLAN0_IDX)
+    {
+    return wifi_get_setting(WLAN0_NAME, psetting);
+    }
+    else
+    {
+    return wifi_get_setting(WLAN1_NAME, psetting);
+    }
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/component/common/application/matter/common/port/matter_wifis.h
+++ b/component/common/application/matter/common/port/matter_wifis.h
@@ -5,6 +5,9 @@
  *
  * @note rmtp is ignored, as signals are not implemented.
  */
+#ifndef MATTER_WIFIS_H_
+#define MATTER_WIFIS_H_
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -13,6 +16,14 @@ extern "C" {
 #include <lwip_netconf.h>
 
 #define JOIN_HANDSHAKE_DONE (uint32_t)(1 << 7)
+
+typedef enum{
+    MATTER_WIFI_EVENT_CONNECT = 0,
+    MATTER_WIFI_EVENT_FOURWAY_HANDSHAKE_DONE = 1,
+    MATTER_WIFI_EVENT_DISCONNECT = 2,
+    MATTER_WIFI_EVENT_DHCP6_DONE = 3,
+} matter_wifi_event;
+
 extern uint32_t rtw_join_status;
 
 void wifi_btcoex_set_bt_on(void);
@@ -53,8 +64,8 @@ void matter_lwip_dhcp6(void);
 void matter_lwip_releaseip(void);
 int matter_wifi_get_ap_bssid(unsigned char*);
 int matter_wifi_get_network_mode(rtw_network_mode_t *pmode);
-int matter_wifi_get_security_type(const char *ifname, uint16_t *alg, uint8_t *key_idx, uint8_t *passphrase);
-int matter_wifi_get_wifi_channel_number(const char *ifname, uint8_t *ch);
+int matter_wifi_get_security_type(uint8_t wlan_idx, uint16_t *alg, uint8_t *key_idx, uint8_t *passphrase);
+int matter_wifi_get_wifi_channel_number(uint8_t wlan_idx, uint8_t *ch);
 int matter_wifi_get_rssi(int *prssi);
 int matter_wifi_get_mac_address(char *mac);
 int matter_wifi_get_last_error(void);
@@ -68,7 +79,10 @@ unsigned char *matter_LwIP_GetIP(uint8_t idx);
 unsigned char *matter_LwIP_GetGW(uint8_t idx);
 uint8_t *matter_LwIP_GetMASK(uint8_t idx);
 int matter_wifi_get_setting(unsigned char wlan_idx, rtw_wifi_setting_t *psetting);
+void matter_wifi_reg_event_handler(matter_wifi_event event_cmds, rtw_event_handler_t handler_func, void *handler_user_data);
 
 #ifdef __cplusplus
 }
 #endif
+
+#endif //MATTER_WIFIS_H_

--- a/component/common/application/matter/common/port/matter_wifis.h
+++ b/component/common/application/matter/common/port/matter_wifis.h
@@ -58,8 +58,12 @@ int matter_wifi_get_wifi_channel_number(const char *ifname, uint8_t *ch);
 int matter_wifi_get_rssi(int *prssi);
 int matter_wifi_get_mac_address(char *mac);
 int matter_wifi_get_last_error(void);
+#if LWIP_VERSION_MAJOR > 2 || LWIP_VERSION_MINOR > 0
+#if LWIP_IPV6
 uint8_t *matter_LwIP_GetIPv6_linklocal(uint8_t idx);
 uint8_t *matter_LwIP_GetIPv6_global(uint8_t idx);
+#endif // LWIP_IPV6
+#endif // LWIP_VERSION_MAJOR > 2 || LWIP_VERSION_MINOR > 0
 unsigned char *matter_LwIP_GetIP(uint8_t idx);
 unsigned char *matter_LwIP_GetGW(uint8_t idx);
 uint8_t *matter_LwIP_GetMASK(uint8_t idx);

--- a/component/common/application/matter/common/port/matter_wifis.h
+++ b/component/common/application/matter/common/port/matter_wifis.h
@@ -58,6 +58,12 @@ int matter_wifi_get_wifi_channel_number(const char *ifname, uint8_t *ch);
 int matter_wifi_get_rssi(int *prssi);
 int matter_wifi_get_mac_address(char *mac);
 int matter_wifi_get_last_error(void);
+uint8_t *matter_LwIP_GetIPv6_linklocal(uint8_t idx);
+uint8_t *matter_LwIP_GetIPv6_global(uint8_t idx);
+unsigned char *matter_LwIP_GetIP(uint8_t idx);
+unsigned char *matter_LwIP_GetGW(uint8_t idx);
+uint8_t *matter_LwIP_GetMASK(uint8_t idx);
+int matter_wifi_get_setting(unsigned char wlan_idx, rtw_wifi_setting_t *psetting);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- Added matter API for lwip and wifi functions in matter_wifis.c/h including:
  - matter_LwIP_GetIPv6_linklocal
  - matter_LwIP_GetIPv6_global
  - matter_LwIP_GetIP
  - matter_LwIP_GetGW
  - matter_LwIP_GetMASK
  - matter_wifi_get_setting
  - matter_wifi_reg_event_handler
- Modified matter API arguments for wifi functions in matter_wifis.c/h including:
  - matter_wifi_get_security_type
  - matter_wifi_get_wifi_channel_number
- Included wifi_structures.h in chip_porting.h