### PR TITLE
[build] fix build issue with MatterReportingAttributeChangeCallback

### DIFF
--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip/light_switch_app/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip/light_switch_app/Makefile
@@ -55,6 +55,7 @@ GENERATE_NINJA:
 	echo ameba_cpu = \"ameba\"               >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_inet_config_enable_ipv4 = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_enable_ota_requestor = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_build_libshell = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_logging = "true" >> $(OUTPUT_DIR)/args.gn && \

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/air_purifier_app/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/air_purifier_app/Makefile
@@ -111,6 +111,7 @@ CPPSRC += $(CODEGEN_DIR)/app/cluster-init-callback.cpp
 CPPSRC += $(CODEGEN_DIR)/zap-generated/IMClusterCommandHandler.cpp
 
 CPPSRC += $(CHIPDIR)/src/app/reporting/Engine.cpp
+CPPSRC += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 CPPSRC += $(CHIPDIR)/src/lib/dnssd/minimal_mdns/responders/IP.cpp
 

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/aircon_port/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/aircon_port/Makefile
@@ -115,6 +115,7 @@ CPPSRC += $(CODEGEN_DIR)/app/cluster-init-callback.cpp
 CPPSRC += $(CODEGEN_DIR)/zap-generated/IMClusterCommandHandler.cpp
 
 CPPSRC += $(CHIPDIR)/src/app/reporting/Engine.cpp
+CPPSRC += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 CPPSRC += $(CHIPDIR)/src/lib/dnssd/minimal_mdns/responders/IP.cpp
 

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/all_clusters_app/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/all_clusters_app/Makefile
@@ -110,6 +110,7 @@ CPPSRC += $(CHIPDIR)/src/app/util/util.cpp
 CPPSRC += $(CHIPDIR)/src/app/util/privilege-storage.cpp
 
 CPPSRC += $(CHIPDIR)/src/app/reporting/Engine.cpp
+CPPSRC += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 CPPSRC += $(shell cat $(CODEGEN_DIR)/cluster-file.txt)
 

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/bridge_dm_app/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/bridge_dm_app/Makefile
@@ -118,6 +118,7 @@ CPPSRC += $(CODEGEN_DIR)/app/cluster-init-callback.cpp
 CPPSRC += $(CODEGEN_DIR)/zap-generated/IMClusterCommandHandler.cpp
 
 CPPSRC += $(CHIPDIR)/src/app/reporting/Engine.cpp
+CPPSRC += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 CPPSRC += $(CHIPDIR)/src/lib/dnssd/minimal_mdns/responders/IP.cpp
 

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/bridge_port/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/bridge_port/Makefile
@@ -118,6 +118,7 @@ CPPSRC += $(CODEGEN_DIR)/app/cluster-init-callback.cpp
 CPPSRC += $(CODEGEN_DIR)/zap-generated/IMClusterCommandHandler.cpp
 
 CPPSRC += $(CHIPDIR)/src/app/reporting/Engine.cpp
+CPPSRC += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 CPPSRC += $(CHIPDIR)/src/lib/dnssd/minimal_mdns/responders/IP.cpp
 

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/dishwasher_port/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/dishwasher_port/Makefile
@@ -119,6 +119,7 @@ CPPSRC += $(CODEGEN_DIR)/app/cluster-init-callback.cpp
 CPPSRC += $(CODEGEN_DIR)/zap-generated/IMClusterCommandHandler.cpp
 
 CPPSRC += $(CHIPDIR)/src/app/reporting/Engine.cpp
+CPPSRC += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 CPPSRC += $(CHIPDIR)/src/lib/dnssd/minimal_mdns/responders/IP.cpp
 

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/laundrywasher_port/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/laundrywasher_port/Makefile
@@ -119,6 +119,7 @@ CPPSRC += $(CODEGEN_DIR)/app/cluster-init-callback.cpp
 CPPSRC += $(CODEGEN_DIR)/zap-generated/IMClusterCommandHandler.cpp
 
 CPPSRC += $(CHIPDIR)/src/app/reporting/Engine.cpp
+CPPSRC += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 CPPSRC += $(CHIPDIR)/src/lib/dnssd/minimal_mdns/responders/IP.cpp
 

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/light_switch_app/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/light_switch_app/Makefile
@@ -39,12 +39,11 @@ DIR += $(CHIPDIR)/examples/light-switch-app/light-switch-common
 DIR += $(CHIPDIR)/examples/light-switch-app/ameba/main
 DIR += $(CHIPDIR)/examples/platform/ameba/ota
 DIR += $(CHIPDIR)/examples/platform/ameba/route_hook
+DIR += $(CHIPDIR)/examples/platform/ameba/shell
 DIR += $(CHIPDIR)/examples/providers
-DIR += $(CHIPDIR)/zzz_generated/light-switch-app/zap-generated
 DIR += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated
 DIR += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/attributes
 DIR += $(BASEDIR)/component/common/application/matter/api
-DIR += $(BASEDIR)/tools/matter/codegen_helpers/gen/app
 DIR += $(CODEGEN_DIR)/app
 DIR += $(CODEGEN_DIR)/zap-generated
 
@@ -56,6 +55,7 @@ vpath %.c $(DIR) $(shell find $(DIR) -type d)
 
 GLOBAL_CFLAGS += -DCHIP_PROJECT=1
 GLOBAL_CFLAGS += -DCHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER=\"lib/address_resolve/AddressResolve_DefaultImpl.h\"
+GLOBAL_CFLAGS += -DCONFIG_ENABLE_CHIP_SHELL=1
 
 #*****************************************************************************#
 #                               Include FILE LIST                             #
@@ -114,12 +114,14 @@ CPPSRC += $(CODEGEN_DIR)/app/cluster-init-callback.cpp
 CPPSRC += $(CODEGEN_DIR)/zap-generated/IMClusterCommandHandler.cpp
 
 CPPSRC += $(CHIPDIR)/src/app/reporting/Engine.cpp
+CPPSRC += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 CPPSRC += $(CHIPDIR)/src/lib/dnssd/minimal_mdns/responders/IP.cpp
 
 CPPSRC += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
 
 CPPSRC += $(CHIPDIR)/examples/light-switch-app/ameba/main/chipinterface.cpp
+CPPSRC += $(CHIPDIR)/examples/light-switch-app/ameba/main/BindingHandler.cpp
 CPPSRC += $(CHIPDIR)/examples/light-switch-app/ameba/main/DeviceCallbacks.cpp
 CPPSRC += $(CHIPDIR)/examples/light-switch-app/ameba/main/CHIPDeviceManager.cpp
 CPPSRC += $(CHIPDIR)/examples/light-switch-app/ameba/main/Globals.cpp
@@ -128,6 +130,7 @@ CPPSRC += $(CHIPDIR)/examples/light-switch-app/ameba/main/LEDWidget.cpp
 ifeq ($(CHIP_ENABLE_OTA_REQUESTOR), true)
 CPPSRC += $(CHIPDIR)/examples/platform/ameba/ota/OTAInitializer.cpp
 endif
+CPPSRC += $(CHIPDIR)/examples/platform/ameba/shell/launch_shell.cpp
 CPPSRC += $(CHIPDIR)/examples/providers/DeviceInfoProviderImpl.cpp
 
 CPPSRC += $(BASEDIR)/component/common/application/matter/api/matter_api.cpp

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/lighting_app/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/lighting_app/Makefile
@@ -113,6 +113,7 @@ CPPSRC += $(CODEGEN_DIR)/app/cluster-init-callback.cpp
 CPPSRC += $(CODEGEN_DIR)/zap-generated/IMClusterCommandHandler.cpp
 
 CPPSRC += $(CHIPDIR)/src/app/reporting/Engine.cpp
+CPPSRC += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 CPPSRC += $(CHIPDIR)/src/lib/dnssd/minimal_mdns/responders/IP.cpp
 

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/lighting_dm_app/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/lighting_dm_app/Makefile
@@ -122,6 +122,7 @@ CPPSRC += $(CODEGEN_DIR)/app/cluster-init-callback.cpp
 CPPSRC += $(CODEGEN_DIR)/zap-generated/IMClusterCommandHandler.cpp
 
 CPPSRC += $(CHIPDIR)/src/app/reporting/Engine.cpp
+CPPSRC += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 CPPSRC += $(CHIPDIR)/src/lib/dnssd/minimal_mdns/responders/IP.cpp
 

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/lighting_port/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/lighting_port/Makefile
@@ -122,6 +122,7 @@ CPPSRC += $(CODEGEN_DIR)/app/cluster-init-callback.cpp
 CPPSRC += $(CODEGEN_DIR)/zap-generated/IMClusterCommandHandler.cpp
 
 CPPSRC += $(CHIPDIR)/src/app/reporting/Engine.cpp
+CPPSRC += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 CPPSRC += $(CHIPDIR)/src/lib/dnssd/minimal_mdns/responders/IP.cpp
 

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/refrigerator_port/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/refrigerator_port/Makefile
@@ -122,6 +122,7 @@ CPPSRC += $(CODEGEN_DIR)/app/cluster-init-callback.cpp
 CPPSRC += $(CODEGEN_DIR)/zap-generated/IMClusterCommandHandler.cpp
 
 CPPSRC += $(CHIPDIR)/src/app/reporting/Engine.cpp
+CPPSRC += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 CPPSRC += $(CHIPDIR)/src/lib/dnssd/minimal_mdns/responders/IP.cpp
 

--- a/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/thermostat_port/Makefile
+++ b/project/realtek_amebaD_va0_example/GCC-RELEASE/project_hp/asdk/make/chip_main/thermostat_port/Makefile
@@ -122,6 +122,7 @@ CPPSRC += $(CODEGEN_DIR)/app/cluster-init-callback.cpp
 CPPSRC += $(CODEGEN_DIR)/zap-generated/IMClusterCommandHandler.cpp
 
 CPPSRC += $(CHIPDIR)/src/app/reporting/Engine.cpp
+CPPSRC += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 CPPSRC += $(CHIPDIR)/src/lib/dnssd/minimal_mdns/responders/IP.cpp
 


### PR DESCRIPTION
* MatterReportingAttributeChangeCallback was removed from ember-compatibility-functions.cpp and added into reporting.cpp in SHA:d338455 of connectedhomeip
* Enable Matter Shell for light_switch