### PR TITLE
[tools] fix number of DAC generated by gen-certs-enhanced.sh

### DIFF
--- a/tools/matter/factorydata/gen-certs-enhanced.sh
+++ b/tools/matter/factorydata/gen-certs-enhanced.sh
@@ -120,7 +120,7 @@ certification_type=1
 	
 	read -p 'How many DAC do you want to generate? ' number
 
-	for (( i=1; i<$number; i++ ))
+	for (( i=1; i<=$number; i++ ))
 	do
 		dac_key_file="$dest_dir/Chip-Test-DAC-$vid-$pid-Key-$i"
 		dac_cert_file="$dest_dir/Chip-Test-DAC-$vid-$pid-Cert-$i"


### PR DESCRIPTION
This PR fixes an issue with gen-certs-enhanced.sh not generating DAC when requesting for 1 DAC

# Setup
```bash
cd tools/matter/factorydata
sudo chmod u+x gen-certs-enhanced.sh
```

# Before fix

## Run gen-certs-enhanced.sh
```bash
./gen-certs-enhanced.sh ~/dev/connectedhomeip ~/dev/connectedhomeip/out/host/chip-cert 1 2
```

```bash
Is PAI vid-scoped (y/n)? n
How many DAC do you want to generate? 1
```

## No DAC generated
```bash
ls myattestation | grep DAC
```


# After applying fix (changing comparison operator to <=) on gen-certs-enhanced.sh

## Remove previously generated myattestation
```bash
rm -rf myattestation
```

## Re-run gen-certs-enhanced.sh
```bash
./gen-certs-enhanced.sh ~/dev/connectedhomeip ~/dev/connectedhomeip/out/host/chip-cert 1 2
```

```bash
Is PAI vid-scoped (y/n)? n
How many DAC do you want to generate? 1
```

## DAC is generated
```bash
$ ls myattestation | grep DAC
Chip-Test-DAC-1-2-Cert-1.der
Chip-Test-DAC-1-2-Cert-1.pem
Chip-Test-DAC-1-2-Key-1.der
Chip-Test-DAC-1-2-Key-1.pem
```