### PR TITLE
[sdk] Fix ameba_get_clock_time implementation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
               uses: actions/checkout@v3
               with:
                   repository: project-chip/connectedhomeip
-                  ref: master
+                  ref: 70d9a61475d31686f0fde8e7b56f352a0f59b299
                   submodules: recursive
                   path: connectedhomeip
                   

--- a/component/common/application/matter/common/port/matter_timers.c
+++ b/component/common/application/matter/common/port/matter_timers.c
@@ -209,15 +209,14 @@ void matter_rtc_write(long long time)
 
 uint64_t ameba_get_clock_time(void)
 {
-#if 0
+    uint32_t current_tick = 0;
     uint64_t global_us = 0;
-    current_us = gtimer_read_us(&matter_rtc_timer);
+    current_tick = gtimer_read_tick(&matter_rtc_timer);
+    current_us = (uint64_t) current_tick * 1000000 / 32768;
     global_us = ((uint64_t)rtc_counter * US_OVERFLOW_MAX) + (current_us);
     return global_us;
-#else
-    return ((xTaskGetTickCount()) * configTICK_RATE_HZ);
-#endif
 }
+
 
 static void matter_timer_rtc_callback(void)
 {
@@ -226,7 +225,6 @@ static void matter_timer_rtc_callback(void)
 
 void matter_timer_init(void)
 {
-    //currently unable to use gtimer, as it will lead to hang issue.
     gtimer_init(&matter_rtc_timer, MATTER_SW_RTC_TIMER_ID);
     gtimer_start_periodical(&matter_rtc_timer, US_OVERFLOW_MAX, (void *)matter_timer_rtc_callback, (uint32_t) &matter_rtc_timer);
 }

--- a/component/common/application/matter/core/matter_core.cpp
+++ b/component/common/application/matter/core/matter_core.cpp
@@ -181,6 +181,7 @@ exit:
 
 CHIP_ERROR matter_core_start()
 {
+    matter_timer_init();
     return matter_core_init();
     // matter_core_init_server();
 }

--- a/component/common/application/matter/example/chiptest/example_matter.c
+++ b/component/common/application/matter/example/chiptest/example_matter.c
@@ -11,6 +11,7 @@ static void example_matter_task_thread(void *pvParameters)
         //waiting for Wifi to be initialized
     }
 
+    matter_timer_init();
     ChipTest();
 
     vTaskDelete(NULL);


### PR DESCRIPTION
* Use gtimer_read_tick instead of xTaskGetTickCount because it will hang after 4,294,967,295 micro seconds (overflow)
* Call matter_timer_init before starting matter stack at matter/core/matter_core.cpp and matter/example/chiptest/example_matter.c